### PR TITLE
refactor!: rename ul-hyphen to ul-dash

### DIFF
--- a/dist/remarkdown-zero.attr.css
+++ b/dist/remarkdown-zero.attr.css
@@ -139,15 +139,26 @@
 
 [data-remarkdown] ul {
 	margin-block: 1lh;
-	margin-inline: 3ch 0ch;
-	padding: 0;
+	margin-inline: 0;
+	padding-inline: 3ch 0ch;
 }
-[data-remarkdown] li ul {
-	margin-block: 0;
+[data-remarkdown] :where(ol, ul) ul {
+	margin-block: 0ch;
+}
+
+[data-remarkdown~="ul-dash"] ul {
+	list-style-type: none;
+}
+[data-remarkdown~="ul-dash"] ul > li::before {
+	content: "-"/"";
+	float: inline-start;
+	width: 1ch;
+	margin-inline-start: -3ch;
+	margin-inline-end: 1ch;
 }
 
 [data-remarkdown~="ul-plus"] ul {
-	list-style: none;
+	list-style-type: none;
 }
 [data-remarkdown~="ul-plus"] ul > li::before {
 	content: "+"/"";
@@ -158,7 +169,7 @@
 }
 
 [data-remarkdown~="ul-star"] ul {
-	list-style: none;
+	list-style-type: none;
 }
 [data-remarkdown~="ul-star"] ul > li::before {
 	content: "*"/"";
@@ -168,65 +179,50 @@
 	margin-inline-end: 1ch;
 }
 
-[data-remarkdown~="ul-hyphen"] ul {
-	list-style: none;
-}
-[data-remarkdown~="ul-hyphen"] ul > li::before {
-	content: "-"/"";
-	float: inline-start;
-	width: 1ch;
-	margin-inline-start: -3ch;
-	margin-inline-end: 1ch;
-}
-
 [data-remarkdown] ol {
 	margin-block: 1lh;
-	margin-inline: 3ch 0ch;
-	padding: 0;
+	margin-inline: 0;
+	padding-inline: 3ch 0ch;
+	counter-reset: rmd-ol;
 }
-[data-remarkdown] li ol {
+[data-remarkdown] :where(ol, ul) ol {
 	margin-block: 0;
+}
+[data-remarkdown] ol > li {
+	counter-increment: rmd-ol;
 }
 
 [data-remarkdown~="ol-decimal"] ol {
 	list-style: none;
-	counter-reset: rmd-ol;
-}
-[data-remarkdown~="ol-decimal"] ol > li {
-	counter-increment: rmd-ol;
 }
 [data-remarkdown~="ol-decimal"] ol > li::before {
+	content: counter(rmd-ol) "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -3ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: counter(rmd-ol) "."/"";
 }
 
 [data-remarkdown~="ol-zero"] ol {
 	list-style: none;
 }
 [data-remarkdown~="ol-zero"] ol > li::before {
+	content: "0" "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -3ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: "0."/"";
 }
 
 [data-remarkdown~="ol-alpha"] ol {
 	list-style: none;
-	counter-reset: rmd-ol;
-}
-[data-remarkdown~="ol-alpha"] ol > li {
-	counter-increment: rmd-ol;
 }
 [data-remarkdown~="ol-alpha"] ol > li::before {
+	content: counter(rmd-ol, lower-alpha) "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -3ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: counter(rmd-ol, lower-alpha) "."/"";
 }
 
 [data-remarkdown~="a-bracket"] a {

--- a/dist/remarkdown-zero.css
+++ b/dist/remarkdown-zero.css
@@ -139,15 +139,26 @@
 
 .remarkdown ul {
 	margin-block: 1lh;
-	margin-inline: 3ch 0ch;
-	padding: 0;
+	margin-inline: 0;
+	padding-inline: 3ch 0ch;
 }
-.remarkdown li ul {
-	margin-block: 0;
+.remarkdown :where(ol, ul) ul {
+	margin-block: 0ch;
+}
+
+.remarkdown.ul-dash ul {
+	list-style-type: none;
+}
+.remarkdown.ul-dash ul > li::before {
+	content: "-"/"";
+	float: inline-start;
+	width: 1ch;
+	margin-inline-start: -3ch;
+	margin-inline-end: 1ch;
 }
 
 .remarkdown.ul-plus ul {
-	list-style: none;
+	list-style-type: none;
 }
 .remarkdown.ul-plus ul > li::before {
 	content: "+"/"";
@@ -158,7 +169,7 @@
 }
 
 .remarkdown.ul-star ul {
-	list-style: none;
+	list-style-type: none;
 }
 .remarkdown.ul-star ul > li::before {
 	content: "*"/"";
@@ -168,65 +179,50 @@
 	margin-inline-end: 1ch;
 }
 
-.remarkdown.ul-hyphen ul {
-	list-style: none;
-}
-.remarkdown.ul-hyphen ul > li::before {
-	content: "-"/"";
-	float: inline-start;
-	width: 1ch;
-	margin-inline-start: -3ch;
-	margin-inline-end: 1ch;
-}
-
 .remarkdown ol {
 	margin-block: 1lh;
-	margin-inline: 3ch 0ch;
-	padding: 0;
+	margin-inline: 0;
+	padding-inline: 3ch 0ch;
+	counter-reset: rmd-ol;
 }
-.remarkdown li ol {
+.remarkdown :where(ol, ul) ol {
 	margin-block: 0;
+}
+.remarkdown ol > li {
+	counter-increment: rmd-ol;
 }
 
 .remarkdown.ol-decimal ol {
 	list-style: none;
-	counter-reset: rmd-ol;
-}
-.remarkdown.ol-decimal ol > li {
-	counter-increment: rmd-ol;
 }
 .remarkdown.ol-decimal ol > li::before {
+	content: counter(rmd-ol) "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -3ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: counter(rmd-ol) "."/"";
 }
 
 .remarkdown.ol-zero ol {
 	list-style: none;
 }
 .remarkdown.ol-zero ol > li::before {
+	content: "0" "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -3ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: "0."/"";
 }
 
 .remarkdown.ol-alpha ol {
 	list-style: none;
-	counter-reset: rmd-ol;
-}
-.remarkdown.ol-alpha ol > li {
-	counter-increment: rmd-ol;
 }
 .remarkdown.ol-alpha ol > li::before {
+	content: counter(rmd-ol, lower-alpha) "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -3ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: counter(rmd-ol, lower-alpha) "."/"";
 }
 
 .remarkdown.a-bracket a {

--- a/dist/remarkdown-zero.scope.css
+++ b/dist/remarkdown-zero.scope.css
@@ -127,14 +127,24 @@
 	}
 	ul {
 		margin-block: 1lh;
-		margin-inline: 3ch 0ch;
-		padding: 0;
+		margin-inline: 0;
+		padding-inline: 3ch 0ch;
 	}
-	li ul {
-		margin-block: 0;
+	:where(ol, ul) ul {
+		margin-block: 0ch;
+	}
+	&.ul-dash ul {
+		list-style-type: none;
+	}
+	&.ul-dash ul > li::before {
+		content: "-"/"";
+		float: inline-start;
+		width: 1ch;
+		margin-inline-start: -3ch;
+		margin-inline-end: 1ch;
 	}
 	&.ul-plus ul {
-		list-style: none;
+		list-style-type: none;
 	}
 	&.ul-plus ul > li::before {
 		content: "+"/"";
@@ -144,7 +154,7 @@
 		margin-inline-end: 1ch;
 	}
 	&.ul-star ul {
-		list-style: none;
+		list-style-type: none;
 	}
 	&.ul-star ul > li::before {
 		content: "*"/"";
@@ -153,61 +163,47 @@
 		margin-inline-start: -3ch;
 		margin-inline-end: 1ch;
 	}
-	&.ul-hyphen ul {
-		list-style: none;
-	}
-	&.ul-hyphen ul > li::before {
-		content: "-"/"";
-		float: inline-start;
-		width: 1ch;
-		margin-inline-start: -3ch;
-		margin-inline-end: 1ch;
-	}
 	ol {
 		margin-block: 1lh;
-		margin-inline: 3ch 0ch;
-		padding: 0;
+		margin-inline: 0;
+		padding-inline: 3ch 0ch;
+		counter-reset: rmd-ol;
 	}
-	li ol {
+	:where(ol, ul) ol {
 		margin-block: 0;
+	}
+	ol > li {
+		counter-increment: rmd-ol;
 	}
 	&.ol-decimal ol {
 		list-style: none;
-		counter-reset: rmd-ol;
-	}
-	&.ol-decimal ol > li {
-		counter-increment: rmd-ol;
 	}
 	&.ol-decimal ol > li::before {
+		content: counter(rmd-ol) "."/"";
 		float: inline-start;
+		min-width: 2ch;
 		margin-inline-start: -3ch;
 		margin-inline-end: 1ch;
-		min-width: 2ch;
-		content: counter(rmd-ol) "."/"";
 	}
 	&.ol-zero ol {
 		list-style: none;
 	}
 	&.ol-zero ol > li::before {
+		content: "0" "."/"";
 		float: inline-start;
+		min-width: 2ch;
 		margin-inline-start: -3ch;
 		margin-inline-end: 1ch;
-		min-width: 2ch;
-		content: "0."/"";
 	}
 	&.ol-alpha ol {
 		list-style: none;
-		counter-reset: rmd-ol;
-	}
-	&.ol-alpha ol > li {
-		counter-increment: rmd-ol;
 	}
 	&.ol-alpha ol > li::before {
+		content: counter(rmd-ol, lower-alpha) "."/"";
 		float: inline-start;
+		min-width: 2ch;
 		margin-inline-start: -3ch;
 		margin-inline-end: 1ch;
-		min-width: 2ch;
-		content: counter(rmd-ol, lower-alpha) "."/"";
 	}
 	&.a-bracket a {
 		text-decoration-inset: 1ch;

--- a/dist/remarkdown.attr.css
+++ b/dist/remarkdown.attr.css
@@ -1,5 +1,5 @@
 /*! ReMarkdown 4.0.0-alpha.1 [attr] (MIT) https://fvsch.github.io/remarkdown/ */
-/* includes: all styles; defaults: base-text, hn-reset, hn-prefix, ul-hyphen, ol-decimal, quote-gt, em-reset, em-star, strong-reset, strong-star, a-bracket, code-tick, pre-indent, hr-star; */
+/* includes: all styles; defaults: base-text, hn-reset, hn-prefix, ul-dash, ol-decimal, quote-gt, em-reset, em-star, strong-reset, strong-star, a-bracket, code-tick, pre-indent, hr-star; */
 [data-remarkdown] {
 	--rmd-font: monospace, monospace;
 	--rmd-code-font: inherit;
@@ -139,15 +139,26 @@
 
 [data-remarkdown] ul {
 	margin-block: 1lh;
-	margin-inline: 4ch 0ch;
-	padding: 0;
+	margin-inline: 0;
+	padding-inline: 4ch 0ch;
 }
-[data-remarkdown] li ul {
-	margin-block: 0;
+[data-remarkdown] :where(ol, ul) ul {
+	margin-block: 0ch;
+}
+
+[data-remarkdown] ul {
+	list-style-type: none;
+}
+[data-remarkdown] ul > li::before {
+	content: "-"/"";
+	float: inline-start;
+	width: 1ch;
+	margin-inline-start: -4ch;
+	margin-inline-end: 1ch;
 }
 
 [data-remarkdown~="ul-plus"] ul {
-	list-style: none;
+	list-style-type: none;
 }
 [data-remarkdown~="ul-plus"] ul > li::before {
 	content: "+"/"";
@@ -158,7 +169,7 @@
 }
 
 [data-remarkdown~="ul-star"] ul {
-	list-style: none;
+	list-style-type: none;
 }
 [data-remarkdown~="ul-star"] ul > li::before {
 	content: "*"/"";
@@ -168,65 +179,50 @@
 	margin-inline-end: 1ch;
 }
 
-[data-remarkdown] ul {
-	list-style: none;
-}
-[data-remarkdown] ul > li::before {
-	content: "-"/"";
-	float: inline-start;
-	width: 1ch;
-	margin-inline-start: -4ch;
-	margin-inline-end: 1ch;
-}
-
 [data-remarkdown] ol {
 	margin-block: 1lh;
-	margin-inline: 4ch 0ch;
-	padding: 0;
-}
-[data-remarkdown] li ol {
-	margin-block: 0;
-}
-
-[data-remarkdown] ol {
-	list-style: none;
+	margin-inline: 0;
+	padding-inline: 4ch 0ch;
 	counter-reset: rmd-ol;
+}
+[data-remarkdown] :where(ol, ul) ol {
+	margin-block: 0;
 }
 [data-remarkdown] ol > li {
 	counter-increment: rmd-ol;
 }
+
+[data-remarkdown] ol {
+	list-style: none;
+}
 [data-remarkdown] ol > li::before {
+	content: counter(rmd-ol) "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -4ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: counter(rmd-ol) "."/"";
 }
 
 [data-remarkdown~="ol-zero"] ol {
 	list-style: none;
 }
 [data-remarkdown~="ol-zero"] ol > li::before {
+	content: "0" "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -4ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: "0."/"";
 }
 
 [data-remarkdown~="ol-alpha"] ol {
 	list-style: none;
-	counter-reset: rmd-ol;
-}
-[data-remarkdown~="ol-alpha"] ol > li {
-	counter-increment: rmd-ol;
 }
 [data-remarkdown~="ol-alpha"] ol > li::before {
+	content: counter(rmd-ol, lower-alpha) "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -4ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: counter(rmd-ol, lower-alpha) "."/"";
 }
 
 [data-remarkdown] a {

--- a/dist/remarkdown.css
+++ b/dist/remarkdown.css
@@ -1,5 +1,5 @@
 /*! ReMarkdown 4.0.0-alpha.1 (MIT) https://fvsch.github.io/remarkdown/ */
-/* includes: all styles; defaults: base-text, hn-reset, hn-prefix, ul-hyphen, ol-decimal, quote-gt, em-reset, em-star, strong-reset, strong-star, a-bracket, code-tick, pre-indent, hr-star; */
+/* includes: all styles; defaults: base-text, hn-reset, hn-prefix, ul-dash, ol-decimal, quote-gt, em-reset, em-star, strong-reset, strong-star, a-bracket, code-tick, pre-indent, hr-star; */
 .remarkdown {
 	--rmd-font: monospace, monospace;
 	--rmd-code-font: inherit;
@@ -139,15 +139,26 @@
 
 .remarkdown ul {
 	margin-block: 1lh;
-	margin-inline: 4ch 0ch;
-	padding: 0;
+	margin-inline: 0;
+	padding-inline: 4ch 0ch;
 }
-.remarkdown li ul {
-	margin-block: 0;
+.remarkdown :where(ol, ul) ul {
+	margin-block: 0ch;
+}
+
+.remarkdown ul {
+	list-style-type: none;
+}
+.remarkdown ul > li::before {
+	content: "-"/"";
+	float: inline-start;
+	width: 1ch;
+	margin-inline-start: -4ch;
+	margin-inline-end: 1ch;
 }
 
 .remarkdown.ul-plus ul {
-	list-style: none;
+	list-style-type: none;
 }
 .remarkdown.ul-plus ul > li::before {
 	content: "+"/"";
@@ -158,7 +169,7 @@
 }
 
 .remarkdown.ul-star ul {
-	list-style: none;
+	list-style-type: none;
 }
 .remarkdown.ul-star ul > li::before {
 	content: "*"/"";
@@ -168,65 +179,50 @@
 	margin-inline-end: 1ch;
 }
 
-.remarkdown ul {
-	list-style: none;
-}
-.remarkdown ul > li::before {
-	content: "-"/"";
-	float: inline-start;
-	width: 1ch;
-	margin-inline-start: -4ch;
-	margin-inline-end: 1ch;
-}
-
 .remarkdown ol {
 	margin-block: 1lh;
-	margin-inline: 4ch 0ch;
-	padding: 0;
-}
-.remarkdown li ol {
-	margin-block: 0;
-}
-
-.remarkdown ol {
-	list-style: none;
+	margin-inline: 0;
+	padding-inline: 4ch 0ch;
 	counter-reset: rmd-ol;
+}
+.remarkdown :where(ol, ul) ol {
+	margin-block: 0;
 }
 .remarkdown ol > li {
 	counter-increment: rmd-ol;
 }
+
+.remarkdown ol {
+	list-style: none;
+}
 .remarkdown ol > li::before {
+	content: counter(rmd-ol) "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -4ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: counter(rmd-ol) "."/"";
 }
 
 .remarkdown.ol-zero ol {
 	list-style: none;
 }
 .remarkdown.ol-zero ol > li::before {
+	content: "0" "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -4ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: "0."/"";
 }
 
 .remarkdown.ol-alpha ol {
 	list-style: none;
-	counter-reset: rmd-ol;
-}
-.remarkdown.ol-alpha ol > li {
-	counter-increment: rmd-ol;
 }
 .remarkdown.ol-alpha ol > li::before {
+	content: counter(rmd-ol, lower-alpha) "."/"";
 	float: inline-start;
+	min-width: 2ch;
 	margin-inline-start: -4ch;
 	margin-inline-end: 1ch;
-	min-width: 2ch;
-	content: counter(rmd-ol, lower-alpha) "."/"";
 }
 
 .remarkdown a {

--- a/dist/remarkdown.scope.css
+++ b/dist/remarkdown.scope.css
@@ -1,5 +1,5 @@
 /*! ReMarkdown 4.0.0-alpha.1 [scope] (MIT) https://fvsch.github.io/remarkdown/ */
-/* includes: all styles; defaults: base-text, hn-reset, hn-prefix, ul-hyphen, ol-decimal, quote-gt, em-reset, em-star, strong-reset, strong-star, a-bracket, code-tick, pre-indent, hr-star; */
+/* includes: all styles; defaults: base-text, hn-reset, hn-prefix, ul-dash, ol-decimal, quote-gt, em-reset, em-star, strong-reset, strong-star, a-bracket, code-tick, pre-indent, hr-star; */
 @scope (.remarkdown) to (.remarkdown-off) {
 	--rmd-font: monospace, monospace;
 	--rmd-code-font: inherit;
@@ -127,14 +127,24 @@
 	}
 	ul {
 		margin-block: 1lh;
-		margin-inline: 4ch 0ch;
-		padding: 0;
+		margin-inline: 0;
+		padding-inline: 4ch 0ch;
 	}
-	li ul {
-		margin-block: 0;
+	:where(ol, ul) ul {
+		margin-block: 0ch;
+	}
+	ul {
+		list-style-type: none;
+	}
+	ul > li::before {
+		content: "-"/"";
+		float: inline-start;
+		width: 1ch;
+		margin-inline-start: -4ch;
+		margin-inline-end: 1ch;
 	}
 	&.ul-plus ul {
-		list-style: none;
+		list-style-type: none;
 	}
 	&.ul-plus ul > li::before {
 		content: "+"/"";
@@ -144,7 +154,7 @@
 		margin-inline-end: 1ch;
 	}
 	&.ul-star ul {
-		list-style: none;
+		list-style-type: none;
 	}
 	&.ul-star ul > li::before {
 		content: "*"/"";
@@ -153,61 +163,47 @@
 		margin-inline-start: -4ch;
 		margin-inline-end: 1ch;
 	}
-	ul {
-		list-style: none;
-	}
-	ul > li::before {
-		content: "-"/"";
-		float: inline-start;
-		width: 1ch;
-		margin-inline-start: -4ch;
-		margin-inline-end: 1ch;
-	}
 	ol {
 		margin-block: 1lh;
-		margin-inline: 4ch 0ch;
-		padding: 0;
-	}
-	li ol {
-		margin-block: 0;
-	}
-	ol {
-		list-style: none;
+		margin-inline: 0;
+		padding-inline: 4ch 0ch;
 		counter-reset: rmd-ol;
+	}
+	:where(ol, ul) ol {
+		margin-block: 0;
 	}
 	ol > li {
 		counter-increment: rmd-ol;
 	}
+	ol {
+		list-style: none;
+	}
 	ol > li::before {
+		content: counter(rmd-ol) "."/"";
 		float: inline-start;
+		min-width: 2ch;
 		margin-inline-start: -4ch;
 		margin-inline-end: 1ch;
-		min-width: 2ch;
-		content: counter(rmd-ol) "."/"";
 	}
 	&.ol-zero ol {
 		list-style: none;
 	}
 	&.ol-zero ol > li::before {
+		content: "0" "."/"";
 		float: inline-start;
+		min-width: 2ch;
 		margin-inline-start: -4ch;
 		margin-inline-end: 1ch;
-		min-width: 2ch;
-		content: "0."/"";
 	}
 	&.ol-alpha ol {
 		list-style: none;
-		counter-reset: rmd-ol;
-	}
-	&.ol-alpha ol > li {
-		counter-increment: rmd-ol;
 	}
 	&.ol-alpha ol > li::before {
+		content: counter(rmd-ol, lower-alpha) "."/"";
 		float: inline-start;
+		min-width: 2ch;
 		margin-inline-start: -4ch;
 		margin-inline-end: 1ch;
-		min-width: 2ch;
-		content: counter(rmd-ol, lower-alpha) "."/"";
 	}
 	a {
 		text-decoration-inset: 1ch;

--- a/docs/demo.css
+++ b/docs/demo.css
@@ -3,7 +3,7 @@
  */
 @layer remarkdown {
 	/*! ReMarkdown 4.0.0-alpha.1 [scope-custom] (MIT) %h */
-	/* includes: all styles; defaults: base-text, hn-reset, hn-prefix, ul-hyphen, ol-decimal, quote-gt, em-reset, em-star, strong-reset, strong-star, a-bracket, code-tick, pre-indent, hr-star; */
+	/* includes: all styles; defaults: base-text, hn-reset, hn-prefix, ul-dash, ol-decimal, quote-gt, em-reset, em-star, strong-reset, strong-star, a-bracket, code-tick, pre-indent, hr-star; */
 	@scope (.remarkdown) to ([data-remarkdown]) {
 		--rmd-font: Menlo, Consolas, DejaVu Sans Mono, ui-monospace, monospace;
 		--rmd-code-font: inherit;
@@ -131,14 +131,24 @@
 		}
 		ul {
 			margin-block: 1lh;
-			margin-inline: 4ch 0ch;
-			padding: 0;
+			margin-inline: 0;
+			padding-inline: 4ch 0ch;
 		}
-		li ul {
-			margin-block: 0;
+		:where(ol, ul) ul {
+			margin-block: 0ch;
+		}
+		ul {
+			list-style-type: none;
+		}
+		ul > li::before {
+			content: "-"/"";
+			float: inline-start;
+			width: 1ch;
+			margin-inline-start: -4ch;
+			margin-inline-end: 1ch;
 		}
 		&.ul-plus ul {
-			list-style: none;
+			list-style-type: none;
 		}
 		&.ul-plus ul > li::before {
 			content: "+"/"";
@@ -148,7 +158,7 @@
 			margin-inline-end: 1ch;
 		}
 		&.ul-star ul {
-			list-style: none;
+			list-style-type: none;
 		}
 		&.ul-star ul > li::before {
 			content: "*"/"";
@@ -157,61 +167,47 @@
 			margin-inline-start: -4ch;
 			margin-inline-end: 1ch;
 		}
-		ul {
-			list-style: none;
-		}
-		ul > li::before {
-			content: "-"/"";
-			float: inline-start;
-			width: 1ch;
-			margin-inline-start: -4ch;
-			margin-inline-end: 1ch;
-		}
 		ol {
 			margin-block: 1lh;
-			margin-inline: 4ch 0ch;
-			padding: 0;
-		}
-		li ol {
-			margin-block: 0;
-		}
-		ol {
-			list-style: none;
+			margin-inline: 0;
+			padding-inline: 4ch 0ch;
 			counter-reset: rmd-ol;
+		}
+		:where(ol, ul) ol {
+			margin-block: 0;
 		}
 		ol > li {
 			counter-increment: rmd-ol;
 		}
+		ol {
+			list-style: none;
+		}
 		ol > li::before {
+			content: counter(rmd-ol) "."/"";
 			float: inline-start;
+			min-width: 2ch;
 			margin-inline-start: -4ch;
 			margin-inline-end: 1ch;
-			min-width: 2ch;
-			content: counter(rmd-ol) "."/"";
 		}
 		&.ol-zero ol {
 			list-style: none;
 		}
 		&.ol-zero ol > li::before {
+			content: "0" "."/"";
 			float: inline-start;
+			min-width: 2ch;
 			margin-inline-start: -4ch;
 			margin-inline-end: 1ch;
-			min-width: 2ch;
-			content: "0."/"";
 		}
 		&.ol-alpha ol {
 			list-style: none;
-			counter-reset: rmd-ol;
-		}
-		&.ol-alpha ol > li {
-			counter-increment: rmd-ol;
 		}
 		&.ol-alpha ol > li::before {
+			content: counter(rmd-ol, lower-alpha) "."/"";
 			float: inline-start;
+			min-width: 2ch;
 			margin-inline-start: -4ch;
 			margin-inline-end: 1ch;
-			min-width: 2ch;
-			content: counter(rmd-ol, lower-alpha) "."/"";
 		}
 		a {
 			text-decoration-inset: 1ch;
@@ -500,14 +496,24 @@
 	}
 	[data-remarkdown] ul {
 		margin-block: 1lh;
-		margin-inline: 3ch 0ch;
-		padding: 0;
+		margin-inline: 0;
+		padding-inline: 3ch 0ch;
 	}
-	[data-remarkdown] li ul {
-		margin-block: 0;
+	[data-remarkdown] :where(ol, ul) ul {
+		margin-block: 0ch;
+	}
+	[data-remarkdown~="ul-dash"] ul {
+		list-style-type: none;
+	}
+	[data-remarkdown~="ul-dash"] ul > li::before {
+		content: "-"/"";
+		float: inline-start;
+		width: 1ch;
+		margin-inline-start: -3ch;
+		margin-inline-end: 1ch;
 	}
 	[data-remarkdown~="ul-plus"] ul {
-		list-style: none;
+		list-style-type: none;
 	}
 	[data-remarkdown~="ul-plus"] ul > li::before {
 		content: "+"/"";
@@ -517,7 +523,7 @@
 		margin-inline-end: 1ch;
 	}
 	[data-remarkdown~="ul-star"] ul {
-		list-style: none;
+		list-style-type: none;
 	}
 	[data-remarkdown~="ul-star"] ul > li::before {
 		content: "*"/"";
@@ -526,61 +532,47 @@
 		margin-inline-start: -3ch;
 		margin-inline-end: 1ch;
 	}
-	[data-remarkdown~="ul-hyphen"] ul {
-		list-style: none;
-	}
-	[data-remarkdown~="ul-hyphen"] ul > li::before {
-		content: "-"/"";
-		float: inline-start;
-		width: 1ch;
-		margin-inline-start: -3ch;
-		margin-inline-end: 1ch;
-	}
 	[data-remarkdown] ol {
 		margin-block: 1lh;
-		margin-inline: 3ch 0ch;
-		padding: 0;
+		margin-inline: 0;
+		padding-inline: 3ch 0ch;
+		counter-reset: rmd-ol;
 	}
-	[data-remarkdown] li ol {
+	[data-remarkdown] :where(ol, ul) ol {
 		margin-block: 0;
+	}
+	[data-remarkdown] ol > li {
+		counter-increment: rmd-ol;
 	}
 	[data-remarkdown~="ol-decimal"] ol {
 		list-style: none;
-		counter-reset: rmd-ol;
-	}
-	[data-remarkdown~="ol-decimal"] ol > li {
-		counter-increment: rmd-ol;
 	}
 	[data-remarkdown~="ol-decimal"] ol > li::before {
+		content: counter(rmd-ol) "."/"";
 		float: inline-start;
+		min-width: 2ch;
 		margin-inline-start: -3ch;
 		margin-inline-end: 1ch;
-		min-width: 2ch;
-		content: counter(rmd-ol) "."/"";
 	}
 	[data-remarkdown~="ol-zero"] ol {
 		list-style: none;
 	}
 	[data-remarkdown~="ol-zero"] ol > li::before {
+		content: "0" "."/"";
 		float: inline-start;
+		min-width: 2ch;
 		margin-inline-start: -3ch;
 		margin-inline-end: 1ch;
-		min-width: 2ch;
-		content: "0."/"";
 	}
 	[data-remarkdown~="ol-alpha"] ol {
 		list-style: none;
-		counter-reset: rmd-ol;
-	}
-	[data-remarkdown~="ol-alpha"] ol > li {
-		counter-increment: rmd-ol;
 	}
 	[data-remarkdown~="ol-alpha"] ol > li::before {
+		content: counter(rmd-ol, lower-alpha) "."/"";
 		float: inline-start;
+		min-width: 2ch;
 		margin-inline-start: -3ch;
 		margin-inline-end: 1ch;
-		min-width: 2ch;
-		content: counter(rmd-ol, lower-alpha) "."/"";
 	}
 	[data-remarkdown~="a-bracket"] a {
 		text-decoration-inset: 1ch;

--- a/docs/styles.html
+++ b/docs/styles.html
@@ -72,7 +72,7 @@
 		<td>Use lowercase letters for OL items</td>
 	</tr>
 	<tr>
-		<td><a href="#ul-hyphen">ul-hyphen</a></td>
+		<td><a href="#ul-dash">ul-dash</a></td>
 		<td>Yes</td>
 		<td>Use “-” for bullets</td>
 	</tr>
@@ -237,11 +237,11 @@
 	Unordered lists
 </h2>
 
-<h3 id="ul-hyphen">
-	Default: <code>ul-hyphen</code>
+<h3 id="ul-dash">
+	Default: <code>ul-dash</code>
 </h3>
 
-<figure data-remarkdown="ul-hyphen">
+<figure data-remarkdown="ul-dash">
 	<ul>
 		<li>This is a list.</li>
 		<li>With a second item.

--- a/lib/config/_config.scss
+++ b/lib/config/_config.scss
@@ -12,6 +12,15 @@
 
 $-config: -base-config(default);
 
+@mixin set($options) {
+	$preset: map.get($options, preset);
+	$base: -base-config($preset);
+	@each $option, $value in $options {
+		@include validate.check-option($option, $value);
+	}
+	$-config: map.merge($base, $options) !global;
+}
+
 @function get($path) {
 	// Check that the config option exists, only checking the first element
 	$first: list.nth($path, 1);
@@ -23,23 +32,15 @@ $-config: -base-config(default);
 	@return map.get($-config, $path...);
 }
 
-@function is-default($names) {
-	$list: get(default-styles);
+/// Return the first option name found in $default-styles
+@function default-option($names) {
+	$defaults: get(default-styles);
 	@each $name in $names {
-		@if list.index($list, $name) != null {
-			@return true;
+		@if list.index($defaults, $name) {
+			@return $name;
 		}
 	}
-	@return false;
-}
-
-@mixin set($options) {
-	$preset: map.get($options, preset);
-	$base: -base-config($preset);
-	@each $option, $value in $options {
-		@include validate.check-option($option, $value);
-	}
-	$-config: map.merge($base, $options) !global;
+	@return null;
 }
 
 @function -base-config($preset) {

--- a/lib/config/_defaults.scss
+++ b/lib/config/_defaults.scss
@@ -47,7 +47,7 @@ $default-styles: (
 	hn-prefix,
 	// h1-line,
 	// h2-line,
-	ul-hyphen,
+	ul-dash,
 	// ul-star,
 	// ul-plus,
 	ol-decimal,

--- a/lib/styles/_ol.scss
+++ b/lib/styles/_ol.scss
@@ -1,56 +1,48 @@
 // <ol>
 // Options: ol-decimal, ol-zero, ol-alpha
 
+@use "sass:string";
 @use "../toolkit" as *;
 
 @mixin ol {
 	@include root() {
 		ol {
 			margin-block: margins(ol);
-			margin-inline: indents(ol);
-			padding: 0;
-		}
-		li ol {
-			margin-block: 0;
-		}
-	}
-
-	@include option(ol-decimal) {
-		@include -ol-li-before(decimal);
-	}
-
-	@include option(ol-zero) {
-		@include -ol-li-before(zero);
-	}
-
-	@include option(ol-alpha) {
-		@include -ol-li-before(alpha);
-	}
-}
-
-@mixin -ol-li-before($type) {
-	ol {
-		list-style: none;
-		@if $type != "zero" {
+			margin-inline: 0;
+			padding-inline: indents(ol);
 			counter-reset: rmd-ol;
 		}
-	}
-	@if $type != "zero" {
+		:where(ol, ul) ol {
+			margin-block: 0;
+		}
 		ol > li {
 			counter-increment: rmd-ol;
 		}
 	}
-	ol > li::before {
-		float: inline-start;
-		margin-inline-start: indent(ol, start) * -1;
-		margin-inline-end: 1ch;
-		min-width: 2ch;
-		@if $type == "zero" {
-			@include content("0.");
-		} @else if $type == "alpha" {
-			@include content(counter(rmd-ol, lower-alpha) ".");
-		} @else {
-			@include content(counter(rmd-ol) ".");
+
+	@each $option in (ol-decimal ol-zero ol-alpha) {
+		@include -ol-option($option);
+	}
+}
+
+@mixin -ol-option($option) {
+	$content: counter(rmd-ol);
+	@if $option == ol-alpha {
+		$content: counter(rmd-ol, lower-alpha);
+	} @else if $option == ol-zero {
+		$content: "0";
+	}
+
+	@include option($option) {
+		ol {
+			list-style: none;
+		}
+		ol > li::before {
+			@include content($content ".");
+			float: inline-start;
+			min-width: 2ch;
+			margin-inline-start: indent(ol, start) * -1;
+			margin-inline-end: 1ch;
 		}
 	}
 }

--- a/lib/styles/_ul.scss
+++ b/lib/styles/_ul.scss
@@ -1,42 +1,45 @@
 // <ul>
-// Options: ul-star, ul-plus, ul-hyphen
+// Options: ul-dash, ul-plus, ul-star
 
 @use "../toolkit" as *;
 
 @mixin ul {
+	$options: (
+		ul-dash: "-",
+		ul-plus: "+",
+		ul-star: "*",
+	);
+
 	@include root() {
 		ul {
 			margin-block: margins(ul);
-			margin-inline: indents(ul);
-			padding: 0;
+			margin-inline: 0;
+			padding-inline: indents(ul);
 		}
-		li ul {
-			margin-block: 0;
+		:where(ol, ul) ul {
+			margin-block: 1ch * 0;
 		}
 	}
 
-	@include option(ul-plus) {
-		@include -ul-li-before("+");
-	}
-
-	@include option(ul-star) {
-		@include -ul-li-before("*");
-	}
-
-	@include option(ul-hyphen) {
-		@include -ul-li-before("-");
+	@each $option, $bullet in $options {
+		@include -ul-option($option, $bullet);
 	}
 }
 
-@mixin -ul-li-before($sign) {
-	ul {
-		list-style: none;
-	}
-	ul > li::before {
-		@include content($sign);
-		float: inline-start;
-		width: 1ch;
-		margin-inline-start: indent(ul, start) * -1;
-		margin-inline-end: 1ch;
+@mixin -ul-option($option, $bullet) {
+	@include option($option) {
+		ul {
+			// Alternatively, we could use a string value for list-style-type,
+			// instead of generating a ::before. The issue is that the generated
+			// ::marker will be harder to style and position correctly.
+			list-style-type: none;
+		}
+		ul > li::before {
+			@include content($bullet);
+			float: inline-start;
+			width: col(1);
+			margin-inline-start: indent(ul, start) * -1;
+			margin-inline-end: col(1);
+		}
 	}
 }

--- a/lib/toolkit/_output.scss
+++ b/lib/toolkit/_output.scss
@@ -67,8 +67,7 @@
 		@error "Unknown direction #{$direction}";
 	}
 	$num: config.get(margins $element "inline-#{$direction}") or 0;
-	$base: config.get(margin-inline-base);
-	@return $num * $base;
+	@return col($num);
 }
 
 /// Get both horizontal margin (indent) values for an element.
@@ -83,6 +82,12 @@
 /// Compute the size of a text line
 @function line($count: 1) {
 	$base: config.get(margin-block-base);
+	@return $base * $count;
+}
+
+/// Compute the size of a text column (typically, one fixed-width character)
+@function col($count: 1) {
+	$base: config.get(margin-inline-base);
 	@return $base * $count;
 }
 

--- a/lib/toolkit/_selector.scss
+++ b/lib/toolkit/_selector.scss
@@ -20,7 +20,7 @@
 /// Outputs nothing if $output-all-styles is false and the option is not
 /// in $defaults.
 @mixin option($name) {
-	@if config.is-default($name) {
+	@if config.default-option($name) {
 		@include root() {
 			@content;
 		}

--- a/lib/toolkit/_utils.scss
+++ b/lib/toolkit/_utils.scss
@@ -36,6 +36,15 @@
 	@return $result;
 }
 
+@function str-pad-end($str, $char, $target-length) {
+	$count: $target-length - string.length($str);
+	@if $count > 0 {
+		@return $str + str-repeat($char, $count);
+	} @else {
+		@return $str;
+	}
+}
+
 @function str-replace($subject, $search, $replacement: "") {
 	$index: string.index($subject, $search);
 	@if $index {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
 		"start": "servitsy docs"
 	},
 	"devDependencies": {
-		"oxfmt": "^0.63.0",
-		"sass": "^1.102.0",
+		"oxfmt": "^0.64.0",
+		"sass": "^1.103.1",
 		"servitsy": "^0.6.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,135 +9,135 @@ importers:
   .:
     devDependencies:
       oxfmt:
-        specifier: ^0.63.0
-        version: 0.63.0
+        specifier: ^0.64.0
+        version: 0.64.0
       sass:
-        specifier: ^1.102.0
-        version: 1.102.0
+        specifier: ^1.103.1
+        version: 1.103.1
       servitsy:
         specifier: ^0.6.0
         version: 0.6.0
 
 packages:
 
-  '@oxfmt/binding-android-arm-eabi@0.63.0':
-    resolution: {integrity: sha512-YmRth4ZPGgEXcgmkhvANbC9uD67dxmSobW7DQuyt5tOBOKvPnIpk5SVHBj88E+7wMNRI2FhqaDbOhQFBix+b8A==}
+  '@oxfmt/binding-android-arm-eabi@0.64.0':
+    resolution: {integrity: sha512-o6uzh/jTOQeAY5TdkAeXdqv7MBRcPxiRA08zrcBtkKj5cSu/FMu0Hl7Q6Fi1KCKyCWZ6lJVjBzdsJvsKltUsGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.63.0':
-    resolution: {integrity: sha512-icbahX8X2X3sRamOMecvdYeZXWjPDazRDIfvWfy7Ca1nc/ZDT2Y9k5Nt7s46EqFd7NQPdgk+CM3/SgIT5LPCaQ==}
+  '@oxfmt/binding-android-arm64@0.64.0':
+    resolution: {integrity: sha512-jRGSUeeP7p3Gynw2YaCVtjBIA6ZxY6bEB/ES5i54OhqmRTyuVg7ZgstEtzgq6GOAJd+2QZ5pvf+bFfmW5Mp9cw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.63.0':
-    resolution: {integrity: sha512-WV+Ze5v5gI2qoj8jpAovt8KBTW8pjEz/AiMXXjeTQS+Bmf/MmZXTS40S8xNPDszX+W8WDv2Bbk6qKrMTtUGu1A==}
+  '@oxfmt/binding-darwin-arm64@0.64.0':
+    resolution: {integrity: sha512-JINwtU2lW7nOFSqi+H2qplipNUqah9Gc1jgGmB82kTD4UnZrZIVxCJ9qEmFiKfjNq27gYLFhrUb0to86aCwMjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.63.0':
-    resolution: {integrity: sha512-CJGSBdDxXOWIpoFXHpverimCvz084KA7L483rqJ44c3jDtzv6d4qOSoR/V9ywSHfV+Ks1lwIj2P49BFhunLNAA==}
+  '@oxfmt/binding-darwin-x64@0.64.0':
+    resolution: {integrity: sha512-gCmuswrgrOSajV4HCRFkVCGIruPq8bjYuPYgSE2WQB3mD6XrdyZ3JMSRZCkQ8zCxOyGWriBo6QoZ5nmMHQ1BfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.63.0':
-    resolution: {integrity: sha512-BDfKY+KhL2078cgswBBFQPAYuxCy93bS/iC5frdSeSbTLcGrR6VC2hsuPTanoJmg84+wSyWl0wWC1eR+uTnkRg==}
+  '@oxfmt/binding-freebsd-x64@0.64.0':
+    resolution: {integrity: sha512-Ab8g7a38pT0MMImjh7anRSTve6buWBIlcXIFBYa5xl4s6UxEgKSc2xOOhbGtLwvXnEi2PsEDGoJh3oUU7xkehQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.63.0':
-    resolution: {integrity: sha512-Ov1cQEXT4mj7cojAokWSS1eoxkoyvbDfAbxNsGIKY2o36kvdAaFzPxRN6NxFRk9fD72B8oCoTTX/NuYTUWlpsg==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.64.0':
+    resolution: {integrity: sha512-BgvS3CoQ+Xy2deoZqEN8JVKabcCZi2RxA3yant8G9OAv9KuPJ9TCjHkqigzdHUVwErZxEP5d2bzLIEyKYyBDLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.63.0':
-    resolution: {integrity: sha512-0LE7ro3+6L79jcMANycAZfRaC7zxr9YZ2+vEL5uMD9QlEep+rS/r1kSJsnuLl991NXJZD60euh0PC1GHrR20vw==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.64.0':
+    resolution: {integrity: sha512-QXpNxwoMj0YvnceCNZadNSden3bIcnvjn/sDp/rwZhRoZoZYGpHvtPyhGsdJz9uvT9GkaMW7SsLddurU56dt8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.63.0':
-    resolution: {integrity: sha512-izPk+2Z4gjuZK32Fqh5qXoMpT/2NXzLh++ob57HiEiVSQZ1iYXu8EKMzb+K5AvWyIEXhdDIt7ADjGGtFhkT9Bw==}
+  '@oxfmt/binding-linux-arm64-gnu@0.64.0':
+    resolution: {integrity: sha512-BBgH3I1ppDsI5pZ4Pdhw0ceYxwVCfbU/bZEBCeZ6caRS9x0ZabErxubP7riGUn11PXZBhe8DYdjkDKP1FlVQ5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.63.0':
-    resolution: {integrity: sha512-alPmbOuWXFXiSo+lOtv6X71C7SYMEDW2WVvywOvf9BwKgEhSNGhMTLeFVSjKUMCamcjbbgVdsWF8GN1uy8xshg==}
+  '@oxfmt/binding-linux-arm64-musl@0.64.0':
+    resolution: {integrity: sha512-v19HSjC/BGXdt26qEvKZtwAHgGmQ2Agcap2kQP+KIqoRZqivVzYth3ui2dJA1i+6/fjpjga85lIOaJJjQ/bOOw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.63.0':
-    resolution: {integrity: sha512-BdzCPvolJc4AWZ+YMzgUDJcDzbQWrFjYuqBHoNHNqP1aCaluQRJNs4k3vNU5IG7vTpjf9zeD73D7MFM1TecZpg==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.64.0':
+    resolution: {integrity: sha512-PElLnOo4xFTBZrxPhgTIj0eHqZXwEBQoNWtb7facUV170T0B0FRET0iNbb3LUeLWTybkUW+vsdyv4ihOdyXGyw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.63.0':
-    resolution: {integrity: sha512-7sIgfLzqtNKSkMGsGVyRpHwpjNezRg2XONvUOheFZs95TSZpM0JAuPpA8KrQFsWc4wPU95roX2O69JgH8igOgw==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.64.0':
+    resolution: {integrity: sha512-Qzsg15n4F5CH+MorcRW4MkAEMiLzXmeG+DiDSbP/bBTqCmWOH3K9DHryNrve+JHlV0txS+B6Z9P5Xz+cmWeL+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.63.0':
-    resolution: {integrity: sha512-9Tcg0y0WcVa6Mm9AgcgFMseDS+VkFJZpKZ8We9SpDY4gg5jewSwln+0sO04QLcTS1BtfDl9MwR+NfID8L7PUTg==}
+  '@oxfmt/binding-linux-riscv64-musl@0.64.0':
+    resolution: {integrity: sha512-/GZ358wnQ/Ez4UVnCcZIi56JkY0sOdZ+B108pqXKqZz3jLS59F4KEAB1Qv3fRlObrFEk+3L2vUQ/xoPx+3vjXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.63.0':
-    resolution: {integrity: sha512-qWKC1pEOpx1qYhXaugPhHUeXwSfqEOk2wJH2LqVXGPV5iQYfdAZdt+d2XDiX4DTSWA2QDMUcFB+wEORh3Xn/sA==}
+  '@oxfmt/binding-linux-s390x-gnu@0.64.0':
+    resolution: {integrity: sha512-/C9We3DXegowfLXtVCYHeNiU9azwCDr5cQkEtCVlc74vyn+lLQSPApJ1CZmxAduqeq/Oi3gQ+IVptyhCaTMtkQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.63.0':
-    resolution: {integrity: sha512-S9wXYOiGSqYGS4Fx/TFsY+xDd/7dE5s+rUgbA4TsHiVF9e8J3ZcKmP7dsP/7iqLI9Wz7Ic7TzEr3mdthRCTdrA==}
+  '@oxfmt/binding-linux-x64-gnu@0.64.0':
+    resolution: {integrity: sha512-91KM2CeRWscIEHlj1NsW2WSnzGeq1Ehq+39bfDowTdkn+fcvK/x4Y1RcyqT7glyBjZio0ldkeCG6Usj3v7ASog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.63.0':
-    resolution: {integrity: sha512-5eGyTJuMZNwBSHCivXt8Yuta6GeTYksOPXRk2MIhajiyFGQx7bjaHIwY+ZusAoFHhT157A9x6sktLjYo9D5oMQ==}
+  '@oxfmt/binding-linux-x64-musl@0.64.0':
+    resolution: {integrity: sha512-gw7uEk9I+7zoT1EYLra1eWArIzNcz8e3jkv+Noo2+o2T7wPvsNSQbfoa4DSfZlvn1i6mJ05RiZ4/omaXPDNhQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.63.0':
-    resolution: {integrity: sha512-Rz7hx+Dv3DoW/S6pwVAyjfFXp7/trdQ1zg+vNmsdsdDNlUccugp4XNqambSuEAeP0DaG9k72AtNyfDXCEg0AGw==}
+  '@oxfmt/binding-openharmony-arm64@0.64.0':
+    resolution: {integrity: sha512-HYHFf616FHSPSO07c09mjmXBfQ73wIVM3m0txOiooa5XZkGoxFd6B14PVj0LB0DXIqJ6wAO/dDR/NX/5UUaqnw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.63.0':
-    resolution: {integrity: sha512-T/IuizKN9mr4Xw6YYnptkXRNdLkyIlUZ7c8zfTOBpoytZyJ1BAsMUvsMDEx0X4YvSMpaivm+DR8112rQfzC25g==}
+  '@oxfmt/binding-win32-arm64-msvc@0.64.0':
+    resolution: {integrity: sha512-uQjFp081IZSWD6VAofX2iO2z01awAdHmfC+NrieWIPKrT2hZKQDyq/U18M7ifC0sm0Wz8aHY/p6+FDYIzs/CrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.63.0':
-    resolution: {integrity: sha512-XjrO5FJ5Wl9vsAxtCP1G/eaeT6y1K2s9CICUHGE42cEjou32/J6S+B1KnrOAboj6E7uhJnwPbRSvznWcxNdA0g==}
+  '@oxfmt/binding-win32-ia32-msvc@0.64.0':
+    resolution: {integrity: sha512-lNM6byTAQ881jugzFu8juJTbNRgsUTlswMA6pJmwi1XDvmIqnnb49lcUAs5gz94fCJLrVN+/X3s3jOKqx23WIQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.63.0':
-    resolution: {integrity: sha512-sgsHCQy432OTQH4Ikk3tZptp3GqwnhwUDuY0loBH41zyHWfMZY9v8Dy78wsnSofHejvFozZGgJgBB1A0LQRwMQ==}
+  '@oxfmt/binding-win32-x64-msvc@0.64.0':
+    resolution: {integrity: sha512-BtmbtL/QjMtF1a6C3CqoDluH2IfB6fJt62E+B9RFfUPtFk4Iz9PFS6+y/SzzOvSxc7aUk2Kphwg7Dh8lMbwu6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -246,8 +246,8 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  oxfmt@0.63.0:
-    resolution: {integrity: sha512-kgdDwv35wvVf6554U2Ab8Jnd0zTM+TsEQWwaB70RAjK3gICFAFGO+2Hd3Be27GMoXj3XRL9IKSNRVl7KBQL6iw==}
+  oxfmt@0.64.0:
+    resolution: {integrity: sha512-XZ4GFBN/PLbXKq+0zrgpQfPKYuJlUuj+nzZJY7UpIbFMNyefNLCdN9EwViycNqnYcv0wrn0jXcQLlqJp8RCKBg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -267,8 +267,8 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
-  sass@1.102.0:
-    resolution: {integrity: sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==}
+  sass@1.103.1:
+    resolution: {integrity: sha512-9icZURbP51S6S0QGoyaeqk9uB06GNWxsFYWfH5RgpFgqK5FA8tJcM3AdVxrZEVJ7dz+L87nG95gBKf4VuaMHGw==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -287,61 +287,61 @@ packages:
 
 snapshots:
 
-  '@oxfmt/binding-android-arm-eabi@0.63.0':
+  '@oxfmt/binding-android-arm-eabi@0.64.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.63.0':
+  '@oxfmt/binding-android-arm64@0.64.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.63.0':
+  '@oxfmt/binding-darwin-arm64@0.64.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.63.0':
+  '@oxfmt/binding-darwin-x64@0.64.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.63.0':
+  '@oxfmt/binding-freebsd-x64@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.63.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.63.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.63.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.63.0':
+  '@oxfmt/binding-linux-arm64-musl@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.63.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.63.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.63.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.63.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.63.0':
+  '@oxfmt/binding-linux-x64-gnu@0.64.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.63.0':
+  '@oxfmt/binding-linux-x64-musl@0.64.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.63.0':
+  '@oxfmt/binding-openharmony-arm64@0.64.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.63.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.64.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.63.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.64.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.63.0':
+  '@oxfmt/binding-win32-x64-msvc@0.64.0':
     optional: true
 
   '@parcel/watcher-android-arm64@2.6.0':
@@ -421,36 +421,36 @@ snapshots:
   node-addon-api@7.1.1:
     optional: true
 
-  oxfmt@0.63.0:
+  oxfmt@0.64.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.63.0
-      '@oxfmt/binding-android-arm64': 0.63.0
-      '@oxfmt/binding-darwin-arm64': 0.63.0
-      '@oxfmt/binding-darwin-x64': 0.63.0
-      '@oxfmt/binding-freebsd-x64': 0.63.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.63.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.63.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.63.0
-      '@oxfmt/binding-linux-arm64-musl': 0.63.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.63.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.63.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.63.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.63.0
-      '@oxfmt/binding-linux-x64-gnu': 0.63.0
-      '@oxfmt/binding-linux-x64-musl': 0.63.0
-      '@oxfmt/binding-openharmony-arm64': 0.63.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.63.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.63.0
-      '@oxfmt/binding-win32-x64-msvc': 0.63.0
+      '@oxfmt/binding-android-arm-eabi': 0.64.0
+      '@oxfmt/binding-android-arm64': 0.64.0
+      '@oxfmt/binding-darwin-arm64': 0.64.0
+      '@oxfmt/binding-darwin-x64': 0.64.0
+      '@oxfmt/binding-freebsd-x64': 0.64.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.64.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.64.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.64.0
+      '@oxfmt/binding-linux-arm64-musl': 0.64.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.64.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.64.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.64.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.64.0
+      '@oxfmt/binding-linux-x64-gnu': 0.64.0
+      '@oxfmt/binding-linux-x64-musl': 0.64.0
+      '@oxfmt/binding-openharmony-arm64': 0.64.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.64.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.64.0
+      '@oxfmt/binding-win32-x64-msvc': 0.64.0
 
   picomatch@4.0.5:
     optional: true
 
   readdirp@5.0.0: {}
 
-  sass@1.102.0:
+  sass@1.103.1:
     dependencies:
       chokidar: 5.0.0
       immutable: 5.1.9


### PR DESCRIPTION
For #26 I explored generating the ul/ol markers in different ways than `li::before` with `float`, but everything I tried had:

1. low browser support (`::marker`),
2. too many limitations (`list-style-type: "*  "` kinda works for `ul`, but can't take a `counter()` for `ol`),
3. or strange positioning issues (`text-indent` and `display: inline-block` worse than `float: inline-start`, actually).

So this PR only contains some refactoring, including a change in one `ul` option name.