### PR TITLE
feat!: add table-reset and table-border-full

### DIFF
--- a/build.js
+++ b/build.js
@@ -11,7 +11,7 @@ buildAll([
 	['preset/remarkdown-zero.scss', 'dist/remarkdown-zero.css'],
 	['preset/remarkdown-zero.attr.scss', 'dist/remarkdown-zero.attr.css'],
 	['preset/remarkdown-zero.scope.scss', 'dist/remarkdown-zero.scope.css'],
-	['docs/demo.scss', 'docs/demo.css'],
+	['docs/docs.scss', 'docs/docs.css'],
 ]);
 
 async function buildAll(sources) {

--- a/dist/remarkdown-zero.attr.css
+++ b/dist/remarkdown-zero.attr.css
@@ -9,7 +9,8 @@
 	--rmd-h2-line: "----------------------------------------";
 	--rmd-hr-stars: "* * * *";
 	--rmd-hr-dashes: "-------";
-	--rmd-margin-block-base: 1lh;
+	--rmd-table-vline: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a";
+	--rmd-table-hline: "----------------------------------------";
 }
 
 [data-remarkdown] {
@@ -117,10 +118,15 @@
 }
 
 [data-remarkdown] hr {
-	height: 1lh;
-	line-height: 1lh;
+	height: auto;
 	margin-block: 1lh;
 	margin-inline: 0;
+	line-height: inherit;
+	text-align: start;
+}
+
+[data-remarkdown~="hr-star"] hr,
+[data-remarkdown~="hr-dash"] hr {
 	border: none;
 	color: inherit;
 }
@@ -131,10 +137,12 @@
 
 [data-remarkdown~="hr-star"] hr::before {
 	content: var(--rmd-hr-stars)/"";
+	display: block;
 }
 
 [data-remarkdown~="hr-dash"] hr::before {
 	content: var(--rmd-hr-dashes)/"";
+	display: block;
 }
 
 [data-remarkdown] ul {
@@ -335,10 +343,15 @@
 }
 
 [data-remarkdown~="quote-gt"] blockquote {
+	--rmd-quote-mark: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a";
 	position: relative;
 }
+[data-remarkdown~="quote-gt"] blockquote:dir(rtl) {
+	--rmd-quote-mark: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a";
+}
 [data-remarkdown~="quote-gt"] blockquote::before {
-	content: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a"/"";
+	content: var(--rmd-quote-mark) var(--rmd-quote-mark) var(--rmd-quote-mark)
+		var(--rmd-quote-mark)/"";
 	position: absolute;
 	inset-block: 0;
 	inset-inline-start: -2ch;
@@ -347,54 +360,120 @@
 	white-space: pre;
 	cursor: default;
 }
-[data-remarkdown~="quote-gt"] blockquote:dir(rtl)::before {
-	content: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a"/"";
-}
 
-[data-remarkdown~="del-gfm"] del {
-	text-decoration: none;
+[data-remarkdown~="del-tilde"] del {
+	text-decoration-inset: 2.2ch;
+	text-decoration-thickness: round(up, 0.08em, 0.5px);
 }
-[data-remarkdown~="del-gfm"] del::before,
-[data-remarkdown~="del-gfm"] del::after {
+[data-remarkdown~="del-tilde"] del::before,
+[data-remarkdown~="del-tilde"] del::after {
 	content: "~~"/"";
 }
 
-[data-remarkdown~="table-marker"] table {
+[data-remarkdown~="table-reset"] table {
 	margin-block: 1lh;
 	border-collapse: collapse;
 }
-[data-remarkdown~="table-marker"] tr > * {
-	min-width: 2ch;
-	position: relative;
-	padding: 0;
-	text-align: inherit;
-	vertical-align: top;
-	font-weight: normal;
+[data-remarkdown~="table-reset"] tr > * {
+	padding-block: 0;
+	padding-inline: 1ch;
 	border: none;
+	vertical-align: top;
+	font-weight: inherit;
+	text-align: match-parent;
 }
-[data-remarkdown~="table-marker"] tr > * + * {
-	padding-inline-start: 3ch;
+[data-remarkdown~="table-reset"] tr > :first-child {
+	padding-inline-start: 0;
 }
-[data-remarkdown~="table-marker"] tr:first-child > th:not([scope="row"]) {
+[data-remarkdown~="table-reset"] tr > :last-child {
+	padding-inline-end: 0;
+}
+
+[data-remarkdown~="table-border"] table,
+[data-remarkdown~="table-border-full"] table {
+	--inset-start: 1ch;
+	--inset-end: 1ch;
+	margin-block: 1lh;
+	border-collapse: collapse;
+}
+[data-remarkdown~="table-border"] tr > *,
+[data-remarkdown~="table-border-full"] tr > * {
+	position: relative;
+	padding-block: 0;
+	padding-inline-start: var(--inset-start);
+	padding-inline-end: var(--inset-end);
+	border: none;
+	vertical-align: top;
+	font-weight: inherit;
+	text-align: match-parent;
+}
+
+[data-remarkdown~="table-border"] tr > :first-child {
+	--inset-start: 0ch;
+}
+[data-remarkdown~="table-border"] tr > :last-child {
+	--inset-end: 0ch;
+}
+
+[data-remarkdown~="table-border"] :is(thead th, thead td, th[scope="col"]),
+[data-remarkdown~="table-border-full"] :is(thead th, thead td, th[scope="col"]) {
+	--inset-total: calc(var(--inset-start) + var(--inset-end));
 	padding-bottom: 1lh;
 }
-[data-remarkdown~="table-marker"] tr:first-child > th:not([scope="row"])::after {
-	content: "--------------------------------------------------------------------------------------------------------------"/"";
+[data-remarkdown~="table-border"] :is(thead th, thead td, th[scope="col"])::after,
+[data-remarkdown~="table-border-full"] :is(thead th, thead td, th[scope="col"])::after {
+	content: var(--rmd-table-hline) var(--rmd-table-hline)/"";
 	position: absolute;
 	bottom: 0;
-	inset-inline: 0;
+	inset-inline-start: var(--inset-start);
+	width: calc(100% - var(--inset-total));
+	max-width: 100%;
+	height: 1lh;
 	overflow: hidden;
 	word-break: break-all;
-	height: 1lh;
 }
-[data-remarkdown~="table-marker"] tr:first-child > * + th:not([scope="row"])::after {
-	inset-inline-start: 3ch;
+@supports (width: round(down, 100%, 1ch)) {
+	[data-remarkdown~="table-border"] :is(thead th, thead td, th[scope="col"])::after,
+	[data-remarkdown~="table-border-full"] :is(thead th, thead td, th[scope="col"])::after {
+		width: round(down, 100% - var(--inset-total), 1ch);
+	}
 }
-[data-remarkdown~="table-marker"] tr > * + *::before {
-	content: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a"/"";
+[data-remarkdown~="table-border"] tr > *::before,
+[data-remarkdown~="table-border-full"] tr > *::before {
+	content: none;
 	position: absolute;
 	inset-block: 0;
-	inset-inline-start: 1ch;
+	inset-inline-start: 0;
+	width: 1ch;
 	overflow: hidden;
 	white-space: pre;
+}
+
+[data-remarkdown~="table-border"] table {
+	--inset-start: 2ch;
+}
+[data-remarkdown~="table-border"] tr > :not(:first-child)::before {
+	content: var(--rmd-table-vline)/"";
+}
+
+[data-remarkdown~="table-border-full"] table {
+	--inset-start: 2ch;
+}
+[data-remarkdown~="table-border-full"] tr {
+	position: relative;
+}
+[data-remarkdown~="table-border-full"] tr::after {
+	content: var(--rmd-table-vline)/"";
+	position: absolute;
+	inset-block: 0;
+	inset-inline-end: 0;
+	width: 1ch;
+	overflow: hidden;
+	white-space: pre;
+}
+[data-remarkdown~="table-border-full"] tr > :last-child {
+	--inset-end: 2ch;
+}
+[data-remarkdown~="table-border-full"] tr > *::before {
+	content: var(--rmd-table-vline)/"";
 }

--- a/dist/remarkdown-zero.css
+++ b/dist/remarkdown-zero.css
@@ -9,7 +9,8 @@
 	--rmd-h2-line: "----------------------------------------";
 	--rmd-hr-stars: "* * * *";
 	--rmd-hr-dashes: "-------";
-	--rmd-margin-block-base: 1lh;
+	--rmd-table-vline: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a";
+	--rmd-table-hline: "----------------------------------------";
 }
 
 .remarkdown {
@@ -117,10 +118,15 @@
 }
 
 .remarkdown hr {
-	height: 1lh;
-	line-height: 1lh;
+	height: auto;
 	margin-block: 1lh;
 	margin-inline: 0;
+	line-height: inherit;
+	text-align: start;
+}
+
+.remarkdown.hr-star hr,
+.remarkdown.hr-dash hr {
 	border: none;
 	color: inherit;
 }
@@ -131,10 +137,12 @@
 
 .remarkdown.hr-star hr::before {
 	content: var(--rmd-hr-stars)/"";
+	display: block;
 }
 
 .remarkdown.hr-dash hr::before {
 	content: var(--rmd-hr-dashes)/"";
+	display: block;
 }
 
 .remarkdown ul {
@@ -335,10 +343,15 @@
 }
 
 .remarkdown.quote-gt blockquote {
+	--rmd-quote-mark: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a";
 	position: relative;
 }
+.remarkdown.quote-gt blockquote:dir(rtl) {
+	--rmd-quote-mark: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a";
+}
 .remarkdown.quote-gt blockquote::before {
-	content: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a"/"";
+	content: var(--rmd-quote-mark) var(--rmd-quote-mark) var(--rmd-quote-mark)
+		var(--rmd-quote-mark)/"";
 	position: absolute;
 	inset-block: 0;
 	inset-inline-start: -2ch;
@@ -347,54 +360,120 @@
 	white-space: pre;
 	cursor: default;
 }
-.remarkdown.quote-gt blockquote:dir(rtl)::before {
-	content: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a"/"";
-}
 
-.remarkdown.del-gfm del {
-	text-decoration: none;
+.remarkdown.del-tilde del {
+	text-decoration-inset: 2.2ch;
+	text-decoration-thickness: round(up, 0.08em, 0.5px);
 }
-.remarkdown.del-gfm del::before,
-.remarkdown.del-gfm del::after {
+.remarkdown.del-tilde del::before,
+.remarkdown.del-tilde del::after {
 	content: "~~"/"";
 }
 
-.remarkdown.table-marker table {
+.remarkdown.table-reset table {
 	margin-block: 1lh;
 	border-collapse: collapse;
 }
-.remarkdown.table-marker tr > * {
-	min-width: 2ch;
-	position: relative;
-	padding: 0;
-	text-align: inherit;
-	vertical-align: top;
-	font-weight: normal;
+.remarkdown.table-reset tr > * {
+	padding-block: 0;
+	padding-inline: 1ch;
 	border: none;
+	vertical-align: top;
+	font-weight: inherit;
+	text-align: match-parent;
 }
-.remarkdown.table-marker tr > * + * {
-	padding-inline-start: 3ch;
+.remarkdown.table-reset tr > :first-child {
+	padding-inline-start: 0;
 }
-.remarkdown.table-marker tr:first-child > th:not([scope="row"]) {
+.remarkdown.table-reset tr > :last-child {
+	padding-inline-end: 0;
+}
+
+.remarkdown.table-border table,
+.remarkdown.table-border-full table {
+	--inset-start: 1ch;
+	--inset-end: 1ch;
+	margin-block: 1lh;
+	border-collapse: collapse;
+}
+.remarkdown.table-border tr > *,
+.remarkdown.table-border-full tr > * {
+	position: relative;
+	padding-block: 0;
+	padding-inline-start: var(--inset-start);
+	padding-inline-end: var(--inset-end);
+	border: none;
+	vertical-align: top;
+	font-weight: inherit;
+	text-align: match-parent;
+}
+
+.remarkdown.table-border tr > :first-child {
+	--inset-start: 0ch;
+}
+.remarkdown.table-border tr > :last-child {
+	--inset-end: 0ch;
+}
+
+.remarkdown.table-border :is(thead th, thead td, th[scope="col"]),
+.remarkdown.table-border-full :is(thead th, thead td, th[scope="col"]) {
+	--inset-total: calc(var(--inset-start) + var(--inset-end));
 	padding-bottom: 1lh;
 }
-.remarkdown.table-marker tr:first-child > th:not([scope="row"])::after {
-	content: "--------------------------------------------------------------------------------------------------------------"/"";
+.remarkdown.table-border :is(thead th, thead td, th[scope="col"])::after,
+.remarkdown.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+	content: var(--rmd-table-hline) var(--rmd-table-hline)/"";
 	position: absolute;
 	bottom: 0;
-	inset-inline: 0;
+	inset-inline-start: var(--inset-start);
+	width: calc(100% - var(--inset-total));
+	max-width: 100%;
+	height: 1lh;
 	overflow: hidden;
 	word-break: break-all;
-	height: 1lh;
 }
-.remarkdown.table-marker tr:first-child > * + th:not([scope="row"])::after {
-	inset-inline-start: 3ch;
+@supports (width: round(down, 100%, 1ch)) {
+	.remarkdown.table-border :is(thead th, thead td, th[scope="col"])::after,
+	.remarkdown.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+		width: round(down, 100% - var(--inset-total), 1ch);
+	}
 }
-.remarkdown.table-marker tr > * + *::before {
-	content: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a"/"";
+.remarkdown.table-border tr > *::before,
+.remarkdown.table-border-full tr > *::before {
+	content: none;
 	position: absolute;
 	inset-block: 0;
-	inset-inline-start: 1ch;
+	inset-inline-start: 0;
+	width: 1ch;
 	overflow: hidden;
 	white-space: pre;
+}
+
+.remarkdown.table-border table {
+	--inset-start: 2ch;
+}
+.remarkdown.table-border tr > :not(:first-child)::before {
+	content: var(--rmd-table-vline)/"";
+}
+
+.remarkdown.table-border-full table {
+	--inset-start: 2ch;
+}
+.remarkdown.table-border-full tr {
+	position: relative;
+}
+.remarkdown.table-border-full tr::after {
+	content: var(--rmd-table-vline)/"";
+	position: absolute;
+	inset-block: 0;
+	inset-inline-end: 0;
+	width: 1ch;
+	overflow: hidden;
+	white-space: pre;
+}
+.remarkdown.table-border-full tr > :last-child {
+	--inset-end: 2ch;
+}
+.remarkdown.table-border-full tr > *::before {
+	content: var(--rmd-table-vline)/"";
 }

--- a/dist/remarkdown-zero.scope.css
+++ b/dist/remarkdown-zero.scope.css
@@ -9,7 +9,8 @@
 	--rmd-h2-line: "----------------------------------------";
 	--rmd-hr-stars: "* * * *";
 	--rmd-hr-dashes: "-------";
-	--rmd-margin-block-base: 1lh;
+	--rmd-table-vline: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a";
+	--rmd-table-hline: "----------------------------------------";
 	& {
 		font-family: var(--rmd-font);
 		line-height: var(--rmd-line-height);
@@ -109,10 +110,14 @@
 		margin-inline: 0ch;
 	}
 	hr {
-		height: 1lh;
-		line-height: 1lh;
+		height: auto;
 		margin-block: 1lh;
 		margin-inline: 0;
+		line-height: inherit;
+		text-align: start;
+	}
+	&.hr-star hr,
+	&.hr-dash hr {
 		border: none;
 		color: inherit;
 	}
@@ -121,9 +126,11 @@
 	}
 	&.hr-star hr::before {
 		content: var(--rmd-hr-stars)/"";
+		display: block;
 	}
 	&.hr-dash hr::before {
 		content: var(--rmd-hr-dashes)/"";
+		display: block;
 	}
 	ul {
 		margin-block: 1lh;
@@ -300,10 +307,15 @@
 		padding: 0;
 	}
 	&.quote-gt blockquote {
+		--rmd-quote-mark: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a";
 		position: relative;
 	}
+	&.quote-gt blockquote:dir(rtl) {
+		--rmd-quote-mark: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a";
+	}
 	&.quote-gt blockquote::before {
-		content: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a"/"";
+		content: var(--rmd-quote-mark) var(--rmd-quote-mark) var(--rmd-quote-mark)
+			var(--rmd-quote-mark)/"";
 		position: absolute;
 		inset-block: 0;
 		inset-inline-start: -2ch;
@@ -312,53 +324,114 @@
 		white-space: pre;
 		cursor: default;
 	}
-	&.quote-gt blockquote:dir(rtl)::before {
-		content: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a"/"";
+	&.del-tilde del {
+		text-decoration-inset: 2.2ch;
+		text-decoration-thickness: round(up, 0.08em, 0.5px);
 	}
-	&.del-gfm del {
-		text-decoration: none;
-	}
-	&.del-gfm del::before,
-	&.del-gfm del::after {
+	&.del-tilde del::before,
+	&.del-tilde del::after {
 		content: "~~"/"";
 	}
-	&.table-marker table {
+	&.table-reset table {
 		margin-block: 1lh;
 		border-collapse: collapse;
 	}
-	&.table-marker tr > * {
-		min-width: 2ch;
-		position: relative;
-		padding: 0;
-		text-align: inherit;
-		vertical-align: top;
-		font-weight: normal;
+	&.table-reset tr > * {
+		padding-block: 0;
+		padding-inline: 1ch;
 		border: none;
+		vertical-align: top;
+		font-weight: inherit;
+		text-align: match-parent;
 	}
-	&.table-marker tr > * + * {
-		padding-inline-start: 3ch;
+	&.table-reset tr > :first-child {
+		padding-inline-start: 0;
 	}
-	&.table-marker tr:first-child > th:not([scope="row"]) {
+	&.table-reset tr > :last-child {
+		padding-inline-end: 0;
+	}
+	&.table-border table,
+	&.table-border-full table {
+		--inset-start: 1ch;
+		--inset-end: 1ch;
+		margin-block: 1lh;
+		border-collapse: collapse;
+	}
+	&.table-border tr > *,
+	&.table-border-full tr > * {
+		position: relative;
+		padding-block: 0;
+		padding-inline-start: var(--inset-start);
+		padding-inline-end: var(--inset-end);
+		border: none;
+		vertical-align: top;
+		font-weight: inherit;
+		text-align: match-parent;
+	}
+	&.table-border tr > :first-child {
+		--inset-start: 0ch;
+	}
+	&.table-border tr > :last-child {
+		--inset-end: 0ch;
+	}
+	&.table-border :is(thead th, thead td, th[scope="col"]),
+	&.table-border-full :is(thead th, thead td, th[scope="col"]) {
+		--inset-total: calc(var(--inset-start) + var(--inset-end));
 		padding-bottom: 1lh;
 	}
-	&.table-marker tr:first-child > th:not([scope="row"])::after {
-		content: "--------------------------------------------------------------------------------------------------------------"/"";
+	&.table-border :is(thead th, thead td, th[scope="col"])::after,
+	&.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+		content: var(--rmd-table-hline) var(--rmd-table-hline)/"";
 		position: absolute;
 		bottom: 0;
-		inset-inline: 0;
+		inset-inline-start: var(--inset-start);
+		width: calc(100% - var(--inset-total));
+		max-width: 100%;
+		height: 1lh;
 		overflow: hidden;
 		word-break: break-all;
-		height: 1lh;
 	}
-	&.table-marker tr:first-child > * + th:not([scope="row"])::after {
-		inset-inline-start: 3ch;
+	@supports (width: round(down, 100%, 1ch)) {
+		&.table-border :is(thead th, thead td, th[scope="col"])::after,
+		&.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+			width: round(down, 100% - var(--inset-total), 1ch);
+		}
 	}
-	&.table-marker tr > * + *::before {
-		content: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a"/"";
+	&.table-border tr > *::before,
+	&.table-border-full tr > *::before {
+		content: none;
 		position: absolute;
 		inset-block: 0;
-		inset-inline-start: 1ch;
+		inset-inline-start: 0;
+		width: 1ch;
 		overflow: hidden;
 		white-space: pre;
+	}
+	&.table-border table {
+		--inset-start: 2ch;
+	}
+	&.table-border tr > :not(:first-child)::before {
+		content: var(--rmd-table-vline)/"";
+	}
+	&.table-border-full table {
+		--inset-start: 2ch;
+	}
+	&.table-border-full tr {
+		position: relative;
+	}
+	&.table-border-full tr::after {
+		content: var(--rmd-table-vline)/"";
+		position: absolute;
+		inset-block: 0;
+		inset-inline-end: 0;
+		width: 1ch;
+		overflow: hidden;
+		white-space: pre;
+	}
+	&.table-border-full tr > :last-child {
+		--inset-end: 2ch;
+	}
+	&.table-border-full tr > *::before {
+		content: var(--rmd-table-vline)/"";
 	}
 }

--- a/dist/remarkdown.attr.css
+++ b/dist/remarkdown.attr.css
@@ -9,7 +9,8 @@
 	--rmd-h2-line: "----------------------------------------";
 	--rmd-hr-stars: "* * * *";
 	--rmd-hr-dashes: "-------";
-	--rmd-margin-block-base: 1lh;
+	--rmd-table-vline: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a";
+	--rmd-table-hline: "----------------------------------------";
 }
 
 [data-remarkdown] {
@@ -117,10 +118,14 @@
 }
 
 [data-remarkdown] hr {
-	height: 1lh;
-	line-height: 1lh;
+	height: auto;
 	margin-block: 1lh;
 	margin-inline: 0;
+	line-height: inherit;
+	text-align: start;
+}
+
+[data-remarkdown] hr {
 	border: none;
 	color: inherit;
 }
@@ -131,10 +136,12 @@
 
 [data-remarkdown] hr::before {
 	content: var(--rmd-hr-stars)/"";
+	display: block;
 }
 
 [data-remarkdown~="hr-dash"] hr::before {
 	content: var(--rmd-hr-dashes)/"";
+	display: block;
 }
 
 [data-remarkdown] ul {
@@ -335,10 +342,15 @@
 }
 
 [data-remarkdown] blockquote {
+	--rmd-quote-mark: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a";
 	position: relative;
 }
+[data-remarkdown] blockquote:dir(rtl) {
+	--rmd-quote-mark: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a";
+}
 [data-remarkdown] blockquote::before {
-	content: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a"/"";
+	content: var(--rmd-quote-mark) var(--rmd-quote-mark) var(--rmd-quote-mark)
+		var(--rmd-quote-mark)/"";
 	position: absolute;
 	inset-block: 0;
 	inset-inline-start: -2ch;
@@ -347,54 +359,120 @@
 	white-space: pre;
 	cursor: default;
 }
-[data-remarkdown] blockquote:dir(rtl)::before {
-	content: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a"/"";
-}
 
-[data-remarkdown~="del-gfm"] del {
-	text-decoration: none;
+[data-remarkdown~="del-tilde"] del {
+	text-decoration-inset: 2.2ch;
+	text-decoration-thickness: round(up, 0.08em, 0.5px);
 }
-[data-remarkdown~="del-gfm"] del::before,
-[data-remarkdown~="del-gfm"] del::after {
+[data-remarkdown~="del-tilde"] del::before,
+[data-remarkdown~="del-tilde"] del::after {
 	content: "~~"/"";
 }
 
-[data-remarkdown~="table-marker"] table {
+[data-remarkdown~="table-reset"] table {
 	margin-block: 1lh;
 	border-collapse: collapse;
 }
-[data-remarkdown~="table-marker"] tr > * {
-	min-width: 2ch;
-	position: relative;
-	padding: 0;
-	text-align: inherit;
-	vertical-align: top;
-	font-weight: normal;
+[data-remarkdown~="table-reset"] tr > * {
+	padding-block: 0;
+	padding-inline: 1ch;
 	border: none;
+	vertical-align: top;
+	font-weight: inherit;
+	text-align: match-parent;
 }
-[data-remarkdown~="table-marker"] tr > * + * {
-	padding-inline-start: 3ch;
+[data-remarkdown~="table-reset"] tr > :first-child {
+	padding-inline-start: 0;
 }
-[data-remarkdown~="table-marker"] tr:first-child > th:not([scope="row"]) {
+[data-remarkdown~="table-reset"] tr > :last-child {
+	padding-inline-end: 0;
+}
+
+[data-remarkdown~="table-border"] table,
+[data-remarkdown~="table-border-full"] table {
+	--inset-start: 1ch;
+	--inset-end: 1ch;
+	margin-block: 1lh;
+	border-collapse: collapse;
+}
+[data-remarkdown~="table-border"] tr > *,
+[data-remarkdown~="table-border-full"] tr > * {
+	position: relative;
+	padding-block: 0;
+	padding-inline-start: var(--inset-start);
+	padding-inline-end: var(--inset-end);
+	border: none;
+	vertical-align: top;
+	font-weight: inherit;
+	text-align: match-parent;
+}
+
+[data-remarkdown~="table-border"] tr > :first-child {
+	--inset-start: 0ch;
+}
+[data-remarkdown~="table-border"] tr > :last-child {
+	--inset-end: 0ch;
+}
+
+[data-remarkdown~="table-border"] :is(thead th, thead td, th[scope="col"]),
+[data-remarkdown~="table-border-full"] :is(thead th, thead td, th[scope="col"]) {
+	--inset-total: calc(var(--inset-start) + var(--inset-end));
 	padding-bottom: 1lh;
 }
-[data-remarkdown~="table-marker"] tr:first-child > th:not([scope="row"])::after {
-	content: "--------------------------------------------------------------------------------------------------------------"/"";
+[data-remarkdown~="table-border"] :is(thead th, thead td, th[scope="col"])::after,
+[data-remarkdown~="table-border-full"] :is(thead th, thead td, th[scope="col"])::after {
+	content: var(--rmd-table-hline) var(--rmd-table-hline)/"";
 	position: absolute;
 	bottom: 0;
-	inset-inline: 0;
+	inset-inline-start: var(--inset-start);
+	width: calc(100% - var(--inset-total));
+	max-width: 100%;
+	height: 1lh;
 	overflow: hidden;
 	word-break: break-all;
-	height: 1lh;
 }
-[data-remarkdown~="table-marker"] tr:first-child > * + th:not([scope="row"])::after {
-	inset-inline-start: 3ch;
+@supports (width: round(down, 100%, 1ch)) {
+	[data-remarkdown~="table-border"] :is(thead th, thead td, th[scope="col"])::after,
+	[data-remarkdown~="table-border-full"] :is(thead th, thead td, th[scope="col"])::after {
+		width: round(down, 100% - var(--inset-total), 1ch);
+	}
 }
-[data-remarkdown~="table-marker"] tr > * + *::before {
-	content: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a"/"";
+[data-remarkdown~="table-border"] tr > *::before,
+[data-remarkdown~="table-border-full"] tr > *::before {
+	content: none;
 	position: absolute;
 	inset-block: 0;
-	inset-inline-start: 1ch;
+	inset-inline-start: 0;
+	width: 1ch;
 	overflow: hidden;
 	white-space: pre;
+}
+
+[data-remarkdown~="table-border"] table {
+	--inset-start: 2ch;
+}
+[data-remarkdown~="table-border"] tr > :not(:first-child)::before {
+	content: var(--rmd-table-vline)/"";
+}
+
+[data-remarkdown~="table-border-full"] table {
+	--inset-start: 2ch;
+}
+[data-remarkdown~="table-border-full"] tr {
+	position: relative;
+}
+[data-remarkdown~="table-border-full"] tr::after {
+	content: var(--rmd-table-vline)/"";
+	position: absolute;
+	inset-block: 0;
+	inset-inline-end: 0;
+	width: 1ch;
+	overflow: hidden;
+	white-space: pre;
+}
+[data-remarkdown~="table-border-full"] tr > :last-child {
+	--inset-end: 2ch;
+}
+[data-remarkdown~="table-border-full"] tr > *::before {
+	content: var(--rmd-table-vline)/"";
 }

--- a/dist/remarkdown.css
+++ b/dist/remarkdown.css
@@ -9,7 +9,8 @@
 	--rmd-h2-line: "----------------------------------------";
 	--rmd-hr-stars: "* * * *";
 	--rmd-hr-dashes: "-------";
-	--rmd-margin-block-base: 1lh;
+	--rmd-table-vline: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a";
+	--rmd-table-hline: "----------------------------------------";
 }
 
 .remarkdown {
@@ -117,10 +118,14 @@
 }
 
 .remarkdown hr {
-	height: 1lh;
-	line-height: 1lh;
+	height: auto;
 	margin-block: 1lh;
 	margin-inline: 0;
+	line-height: inherit;
+	text-align: start;
+}
+
+.remarkdown hr {
 	border: none;
 	color: inherit;
 }
@@ -131,10 +136,12 @@
 
 .remarkdown hr::before {
 	content: var(--rmd-hr-stars)/"";
+	display: block;
 }
 
 .remarkdown.hr-dash hr::before {
 	content: var(--rmd-hr-dashes)/"";
+	display: block;
 }
 
 .remarkdown ul {
@@ -335,10 +342,15 @@
 }
 
 .remarkdown blockquote {
+	--rmd-quote-mark: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a";
 	position: relative;
 }
+.remarkdown blockquote:dir(rtl) {
+	--rmd-quote-mark: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a";
+}
 .remarkdown blockquote::before {
-	content: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a"/"";
+	content: var(--rmd-quote-mark) var(--rmd-quote-mark) var(--rmd-quote-mark)
+		var(--rmd-quote-mark)/"";
 	position: absolute;
 	inset-block: 0;
 	inset-inline-start: -2ch;
@@ -347,54 +359,120 @@
 	white-space: pre;
 	cursor: default;
 }
-.remarkdown blockquote:dir(rtl)::before {
-	content: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a"/"";
-}
 
-.remarkdown.del-gfm del {
-	text-decoration: none;
+.remarkdown.del-tilde del {
+	text-decoration-inset: 2.2ch;
+	text-decoration-thickness: round(up, 0.08em, 0.5px);
 }
-.remarkdown.del-gfm del::before,
-.remarkdown.del-gfm del::after {
+.remarkdown.del-tilde del::before,
+.remarkdown.del-tilde del::after {
 	content: "~~"/"";
 }
 
-.remarkdown.table-marker table {
+.remarkdown.table-reset table {
 	margin-block: 1lh;
 	border-collapse: collapse;
 }
-.remarkdown.table-marker tr > * {
-	min-width: 2ch;
-	position: relative;
-	padding: 0;
-	text-align: inherit;
-	vertical-align: top;
-	font-weight: normal;
+.remarkdown.table-reset tr > * {
+	padding-block: 0;
+	padding-inline: 1ch;
 	border: none;
+	vertical-align: top;
+	font-weight: inherit;
+	text-align: match-parent;
 }
-.remarkdown.table-marker tr > * + * {
-	padding-inline-start: 3ch;
+.remarkdown.table-reset tr > :first-child {
+	padding-inline-start: 0;
 }
-.remarkdown.table-marker tr:first-child > th:not([scope="row"]) {
+.remarkdown.table-reset tr > :last-child {
+	padding-inline-end: 0;
+}
+
+.remarkdown.table-border table,
+.remarkdown.table-border-full table {
+	--inset-start: 1ch;
+	--inset-end: 1ch;
+	margin-block: 1lh;
+	border-collapse: collapse;
+}
+.remarkdown.table-border tr > *,
+.remarkdown.table-border-full tr > * {
+	position: relative;
+	padding-block: 0;
+	padding-inline-start: var(--inset-start);
+	padding-inline-end: var(--inset-end);
+	border: none;
+	vertical-align: top;
+	font-weight: inherit;
+	text-align: match-parent;
+}
+
+.remarkdown.table-border tr > :first-child {
+	--inset-start: 0ch;
+}
+.remarkdown.table-border tr > :last-child {
+	--inset-end: 0ch;
+}
+
+.remarkdown.table-border :is(thead th, thead td, th[scope="col"]),
+.remarkdown.table-border-full :is(thead th, thead td, th[scope="col"]) {
+	--inset-total: calc(var(--inset-start) + var(--inset-end));
 	padding-bottom: 1lh;
 }
-.remarkdown.table-marker tr:first-child > th:not([scope="row"])::after {
-	content: "--------------------------------------------------------------------------------------------------------------"/"";
+.remarkdown.table-border :is(thead th, thead td, th[scope="col"])::after,
+.remarkdown.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+	content: var(--rmd-table-hline) var(--rmd-table-hline)/"";
 	position: absolute;
 	bottom: 0;
-	inset-inline: 0;
+	inset-inline-start: var(--inset-start);
+	width: calc(100% - var(--inset-total));
+	max-width: 100%;
+	height: 1lh;
 	overflow: hidden;
 	word-break: break-all;
-	height: 1lh;
 }
-.remarkdown.table-marker tr:first-child > * + th:not([scope="row"])::after {
-	inset-inline-start: 3ch;
+@supports (width: round(down, 100%, 1ch)) {
+	.remarkdown.table-border :is(thead th, thead td, th[scope="col"])::after,
+	.remarkdown.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+		width: round(down, 100% - var(--inset-total), 1ch);
+	}
 }
-.remarkdown.table-marker tr > * + *::before {
-	content: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a"/"";
+.remarkdown.table-border tr > *::before,
+.remarkdown.table-border-full tr > *::before {
+	content: none;
 	position: absolute;
 	inset-block: 0;
-	inset-inline-start: 1ch;
+	inset-inline-start: 0;
+	width: 1ch;
 	overflow: hidden;
 	white-space: pre;
+}
+
+.remarkdown.table-border table {
+	--inset-start: 2ch;
+}
+.remarkdown.table-border tr > :not(:first-child)::before {
+	content: var(--rmd-table-vline)/"";
+}
+
+.remarkdown.table-border-full table {
+	--inset-start: 2ch;
+}
+.remarkdown.table-border-full tr {
+	position: relative;
+}
+.remarkdown.table-border-full tr::after {
+	content: var(--rmd-table-vline)/"";
+	position: absolute;
+	inset-block: 0;
+	inset-inline-end: 0;
+	width: 1ch;
+	overflow: hidden;
+	white-space: pre;
+}
+.remarkdown.table-border-full tr > :last-child {
+	--inset-end: 2ch;
+}
+.remarkdown.table-border-full tr > *::before {
+	content: var(--rmd-table-vline)/"";
 }

--- a/dist/remarkdown.scope.css
+++ b/dist/remarkdown.scope.css
@@ -9,7 +9,8 @@
 	--rmd-h2-line: "----------------------------------------";
 	--rmd-hr-stars: "* * * *";
 	--rmd-hr-dashes: "-------";
-	--rmd-margin-block-base: 1lh;
+	--rmd-table-vline: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a";
+	--rmd-table-hline: "----------------------------------------";
 	& {
 		font-family: var(--rmd-font);
 		line-height: var(--rmd-line-height);
@@ -109,10 +110,13 @@
 		margin-inline: 0ch;
 	}
 	hr {
-		height: 1lh;
-		line-height: 1lh;
+		height: auto;
 		margin-block: 1lh;
 		margin-inline: 0;
+		line-height: inherit;
+		text-align: start;
+	}
+	hr {
 		border: none;
 		color: inherit;
 	}
@@ -121,9 +125,11 @@
 	}
 	hr::before {
 		content: var(--rmd-hr-stars)/"";
+		display: block;
 	}
 	&.hr-dash hr::before {
 		content: var(--rmd-hr-dashes)/"";
+		display: block;
 	}
 	ul {
 		margin-block: 1lh;
@@ -300,10 +306,15 @@
 		padding: 0;
 	}
 	blockquote {
+		--rmd-quote-mark: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a";
 		position: relative;
 	}
+	blockquote:dir(rtl) {
+		--rmd-quote-mark: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a";
+	}
 	blockquote::before {
-		content: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a"/"";
+		content: var(--rmd-quote-mark) var(--rmd-quote-mark) var(--rmd-quote-mark)
+			var(--rmd-quote-mark)/"";
 		position: absolute;
 		inset-block: 0;
 		inset-inline-start: -2ch;
@@ -312,53 +323,114 @@
 		white-space: pre;
 		cursor: default;
 	}
-	blockquote:dir(rtl)::before {
-		content: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a"/"";
+	&.del-tilde del {
+		text-decoration-inset: 2.2ch;
+		text-decoration-thickness: round(up, 0.08em, 0.5px);
 	}
-	&.del-gfm del {
-		text-decoration: none;
-	}
-	&.del-gfm del::before,
-	&.del-gfm del::after {
+	&.del-tilde del::before,
+	&.del-tilde del::after {
 		content: "~~"/"";
 	}
-	&.table-marker table {
+	&.table-reset table {
 		margin-block: 1lh;
 		border-collapse: collapse;
 	}
-	&.table-marker tr > * {
-		min-width: 2ch;
-		position: relative;
-		padding: 0;
-		text-align: inherit;
-		vertical-align: top;
-		font-weight: normal;
+	&.table-reset tr > * {
+		padding-block: 0;
+		padding-inline: 1ch;
 		border: none;
+		vertical-align: top;
+		font-weight: inherit;
+		text-align: match-parent;
 	}
-	&.table-marker tr > * + * {
-		padding-inline-start: 3ch;
+	&.table-reset tr > :first-child {
+		padding-inline-start: 0;
 	}
-	&.table-marker tr:first-child > th:not([scope="row"]) {
+	&.table-reset tr > :last-child {
+		padding-inline-end: 0;
+	}
+	&.table-border table,
+	&.table-border-full table {
+		--inset-start: 1ch;
+		--inset-end: 1ch;
+		margin-block: 1lh;
+		border-collapse: collapse;
+	}
+	&.table-border tr > *,
+	&.table-border-full tr > * {
+		position: relative;
+		padding-block: 0;
+		padding-inline-start: var(--inset-start);
+		padding-inline-end: var(--inset-end);
+		border: none;
+		vertical-align: top;
+		font-weight: inherit;
+		text-align: match-parent;
+	}
+	&.table-border tr > :first-child {
+		--inset-start: 0ch;
+	}
+	&.table-border tr > :last-child {
+		--inset-end: 0ch;
+	}
+	&.table-border :is(thead th, thead td, th[scope="col"]),
+	&.table-border-full :is(thead th, thead td, th[scope="col"]) {
+		--inset-total: calc(var(--inset-start) + var(--inset-end));
 		padding-bottom: 1lh;
 	}
-	&.table-marker tr:first-child > th:not([scope="row"])::after {
-		content: "--------------------------------------------------------------------------------------------------------------"/"";
+	&.table-border :is(thead th, thead td, th[scope="col"])::after,
+	&.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+		content: var(--rmd-table-hline) var(--rmd-table-hline)/"";
 		position: absolute;
 		bottom: 0;
-		inset-inline: 0;
+		inset-inline-start: var(--inset-start);
+		width: calc(100% - var(--inset-total));
+		max-width: 100%;
+		height: 1lh;
 		overflow: hidden;
 		word-break: break-all;
-		height: 1lh;
 	}
-	&.table-marker tr:first-child > * + th:not([scope="row"])::after {
-		inset-inline-start: 3ch;
+	@supports (width: round(down, 100%, 1ch)) {
+		&.table-border :is(thead th, thead td, th[scope="col"])::after,
+		&.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+			width: round(down, 100% - var(--inset-total), 1ch);
+		}
 	}
-	&.table-marker tr > * + *::before {
-		content: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a"/"";
+	&.table-border tr > *::before,
+	&.table-border-full tr > *::before {
+		content: none;
 		position: absolute;
 		inset-block: 0;
-		inset-inline-start: 1ch;
+		inset-inline-start: 0;
+		width: 1ch;
 		overflow: hidden;
 		white-space: pre;
+	}
+	&.table-border table {
+		--inset-start: 2ch;
+	}
+	&.table-border tr > :not(:first-child)::before {
+		content: var(--rmd-table-vline)/"";
+	}
+	&.table-border-full table {
+		--inset-start: 2ch;
+	}
+	&.table-border-full tr {
+		position: relative;
+	}
+	&.table-border-full tr::after {
+		content: var(--rmd-table-vline)/"";
+		position: absolute;
+		inset-block: 0;
+		inset-inline-end: 0;
+		width: 1ch;
+		overflow: hidden;
+		white-space: pre;
+	}
+	&.table-border-full tr > :last-child {
+		--inset-end: 2ch;
+	}
+	&.table-border-full tr > *::before {
+		content: var(--rmd-table-vline)/"";
 	}
 }

--- a/docs/customize.html
+++ b/docs/customize.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<title>ReMarkdown — Configuration</title>
 	<meta name="viewport" content="width=device-width">
-	<link rel="stylesheet" href="./demo.css">
+	<link rel="stylesheet" href="./docs.css">
 </head>
 <body class="remarkdown h1-line h2-line em-underscore">
 

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -1,5 +1,13 @@
 /**
- * Styles for ReMarkdown demo pages
+ * Styles for ReMarkdown documentation pages.
+ *
+ * Includes two builds of ReMarkdown:
+ *
+ * 1. `.remarkdown` class and `default` options preset;
+ * 2. `[data-remarkdown]` attribute and `zero` options preset.
+ *
+ * We're using CSS scoping with `@scope (.remarkdown) to ([data-remarkdown])`
+ * to ensure that we can switch from one build to the other in the same HTML page.
  */
 @layer remarkdown {
 	/*! ReMarkdown 4.0.0-alpha.1 [scope-custom] (MIT) %h */
@@ -13,7 +21,8 @@
 		--rmd-h2-line: "----------------------------------------";
 		--rmd-hr-stars: "* * * *";
 		--rmd-hr-dashes: "-------";
-		--rmd-margin-block-base: 1lh;
+		--rmd-table-vline: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a";
+		--rmd-table-hline: "----------------------------------------";
 		& {
 			font-family: var(--rmd-font);
 			line-height: var(--rmd-line-height);
@@ -113,10 +122,13 @@
 			margin-inline: 0ch;
 		}
 		hr {
-			height: 1lh;
-			line-height: 1lh;
+			height: auto;
 			margin-block: 1lh;
 			margin-inline: 0;
+			line-height: inherit;
+			text-align: start;
+		}
+		hr {
 			border: none;
 			color: inherit;
 		}
@@ -125,9 +137,11 @@
 		}
 		hr::before {
 			content: var(--rmd-hr-stars)/"";
+			display: block;
 		}
 		&.hr-dash hr::before {
 			content: var(--rmd-hr-dashes)/"";
+			display: block;
 		}
 		ul {
 			margin-block: 1lh;
@@ -304,10 +318,15 @@
 			padding: 0;
 		}
 		blockquote {
+			--rmd-quote-mark: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a";
 			position: relative;
 		}
+		blockquote:dir(rtl) {
+			--rmd-quote-mark: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a";
+		}
 		blockquote::before {
-			content: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a"/"";
+			content: var(--rmd-quote-mark) var(--rmd-quote-mark) var(--rmd-quote-mark)
+				var(--rmd-quote-mark)/"";
 			position: absolute;
 			inset-block: 0;
 			inset-inline-start: -2ch;
@@ -316,54 +335,115 @@
 			white-space: pre;
 			cursor: default;
 		}
-		blockquote:dir(rtl)::before {
-			content: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a"/"";
+		&.del-tilde del {
+			text-decoration-inset: 2.2ch;
+			text-decoration-thickness: round(up, 0.08em, 0.5px);
 		}
-		&.del-gfm del {
-			text-decoration: none;
-		}
-		&.del-gfm del::before,
-		&.del-gfm del::after {
+		&.del-tilde del::before,
+		&.del-tilde del::after {
 			content: "~~"/"";
 		}
-		&.table-marker table {
+		&.table-reset table {
 			margin-block: 1lh;
 			border-collapse: collapse;
 		}
-		&.table-marker tr > * {
-			min-width: 2ch;
-			position: relative;
-			padding: 0;
-			text-align: inherit;
-			vertical-align: top;
-			font-weight: normal;
+		&.table-reset tr > * {
+			padding-block: 0;
+			padding-inline: 1ch;
 			border: none;
+			vertical-align: top;
+			font-weight: inherit;
+			text-align: match-parent;
 		}
-		&.table-marker tr > * + * {
-			padding-inline-start: 3ch;
+		&.table-reset tr > :first-child {
+			padding-inline-start: 0;
 		}
-		&.table-marker tr:first-child > th:not([scope="row"]) {
+		&.table-reset tr > :last-child {
+			padding-inline-end: 0;
+		}
+		&.table-border table,
+		&.table-border-full table {
+			--inset-start: 1ch;
+			--inset-end: 1ch;
+			margin-block: 1lh;
+			border-collapse: collapse;
+		}
+		&.table-border tr > *,
+		&.table-border-full tr > * {
+			position: relative;
+			padding-block: 0;
+			padding-inline-start: var(--inset-start);
+			padding-inline-end: var(--inset-end);
+			border: none;
+			vertical-align: top;
+			font-weight: inherit;
+			text-align: match-parent;
+		}
+		&.table-border tr > :first-child {
+			--inset-start: 0ch;
+		}
+		&.table-border tr > :last-child {
+			--inset-end: 0ch;
+		}
+		&.table-border :is(thead th, thead td, th[scope="col"]),
+		&.table-border-full :is(thead th, thead td, th[scope="col"]) {
+			--inset-total: calc(var(--inset-start) + var(--inset-end));
 			padding-bottom: 1lh;
 		}
-		&.table-marker tr:first-child > th:not([scope="row"])::after {
-			content: "--------------------------------------------------------------------------------------------------------------"/"";
+		&.table-border :is(thead th, thead td, th[scope="col"])::after,
+		&.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+			content: var(--rmd-table-hline) var(--rmd-table-hline)/"";
 			position: absolute;
 			bottom: 0;
-			inset-inline: 0;
+			inset-inline-start: var(--inset-start);
+			width: calc(100% - var(--inset-total));
+			max-width: 100%;
+			height: 1lh;
 			overflow: hidden;
 			word-break: break-all;
-			height: 1lh;
 		}
-		&.table-marker tr:first-child > * + th:not([scope="row"])::after {
-			inset-inline-start: 3ch;
+		@supports (width: round(down, 100%, 1ch)) {
+			&.table-border :is(thead th, thead td, th[scope="col"])::after,
+			&.table-border-full :is(thead th, thead td, th[scope="col"])::after {
+				width: round(down, 100% - var(--inset-total), 1ch);
+			}
 		}
-		&.table-marker tr > * + *::before {
-			content: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a"/"";
+		&.table-border tr > *::before,
+		&.table-border-full tr > *::before {
+			content: none;
 			position: absolute;
 			inset-block: 0;
-			inset-inline-start: 1ch;
+			inset-inline-start: 0;
+			width: 1ch;
 			overflow: hidden;
 			white-space: pre;
+		}
+		&.table-border table {
+			--inset-start: 2ch;
+		}
+		&.table-border tr > :not(:first-child)::before {
+			content: var(--rmd-table-vline)/"";
+		}
+		&.table-border-full table {
+			--inset-start: 2ch;
+		}
+		&.table-border-full tr {
+			position: relative;
+		}
+		&.table-border-full tr::after {
+			content: var(--rmd-table-vline)/"";
+			position: absolute;
+			inset-block: 0;
+			inset-inline-end: 0;
+			width: 1ch;
+			overflow: hidden;
+			white-space: pre;
+		}
+		&.table-border-full tr > :last-child {
+			--inset-end: 2ch;
+		}
+		&.table-border-full tr > *::before {
+			content: var(--rmd-table-vline)/"";
 		}
 	}
 	/*! ReMarkdown-zero 4.0.0-alpha.1 [attr] (MIT) https://fvsch.github.io/remarkdown/ */
@@ -377,7 +457,8 @@
 		--rmd-h2-line: "----------------------------------------";
 		--rmd-hr-stars: "* * * *";
 		--rmd-hr-dashes: "-------";
-		--rmd-margin-block-base: 1lh;
+		--rmd-table-vline: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a";
+		--rmd-table-hline: "----------------------------------------";
 	}
 	[data-remarkdown] {
 		font-family: var(--rmd-font);
@@ -478,10 +559,14 @@
 		margin-inline: 0ch;
 	}
 	[data-remarkdown] hr {
-		height: 1lh;
-		line-height: 1lh;
+		height: auto;
 		margin-block: 1lh;
 		margin-inline: 0;
+		line-height: inherit;
+		text-align: start;
+	}
+	[data-remarkdown~="hr-star"] hr,
+	[data-remarkdown~="hr-dash"] hr {
 		border: none;
 		color: inherit;
 	}
@@ -490,9 +575,11 @@
 	}
 	[data-remarkdown~="hr-star"] hr::before {
 		content: var(--rmd-hr-stars)/"";
+		display: block;
 	}
 	[data-remarkdown~="hr-dash"] hr::before {
 		content: var(--rmd-hr-dashes)/"";
+		display: block;
 	}
 	[data-remarkdown] ul {
 		margin-block: 1lh;
@@ -669,10 +756,15 @@
 		padding: 0;
 	}
 	[data-remarkdown~="quote-gt"] blockquote {
+		--rmd-quote-mark: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a";
 		position: relative;
 	}
+	[data-remarkdown~="quote-gt"] blockquote:dir(rtl) {
+		--rmd-quote-mark: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a";
+	}
 	[data-remarkdown~="quote-gt"] blockquote::before {
-		content: ">\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a>\a"/"";
+		content: var(--rmd-quote-mark) var(--rmd-quote-mark) var(--rmd-quote-mark)
+			var(--rmd-quote-mark)/"";
 		position: absolute;
 		inset-block: 0;
 		inset-inline-start: -2ch;
@@ -681,54 +773,115 @@
 		white-space: pre;
 		cursor: default;
 	}
-	[data-remarkdown~="quote-gt"] blockquote:dir(rtl)::before {
-		content: "<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a<\a"/"";
+	[data-remarkdown~="del-tilde"] del {
+		text-decoration-inset: 2.2ch;
+		text-decoration-thickness: round(up, 0.08em, 0.5px);
 	}
-	[data-remarkdown~="del-gfm"] del {
-		text-decoration: none;
-	}
-	[data-remarkdown~="del-gfm"] del::before,
-	[data-remarkdown~="del-gfm"] del::after {
+	[data-remarkdown~="del-tilde"] del::before,
+	[data-remarkdown~="del-tilde"] del::after {
 		content: "~~"/"";
 	}
-	[data-remarkdown~="table-marker"] table {
+	[data-remarkdown~="table-reset"] table {
 		margin-block: 1lh;
 		border-collapse: collapse;
 	}
-	[data-remarkdown~="table-marker"] tr > * {
-		min-width: 2ch;
-		position: relative;
-		padding: 0;
-		text-align: inherit;
-		vertical-align: top;
-		font-weight: normal;
+	[data-remarkdown~="table-reset"] tr > * {
+		padding-block: 0;
+		padding-inline: 1ch;
 		border: none;
+		vertical-align: top;
+		font-weight: inherit;
+		text-align: match-parent;
 	}
-	[data-remarkdown~="table-marker"] tr > * + * {
-		padding-inline-start: 3ch;
+	[data-remarkdown~="table-reset"] tr > :first-child {
+		padding-inline-start: 0;
 	}
-	[data-remarkdown~="table-marker"] tr:first-child > th:not([scope="row"]) {
+	[data-remarkdown~="table-reset"] tr > :last-child {
+		padding-inline-end: 0;
+	}
+	[data-remarkdown~="table-border"] table,
+	[data-remarkdown~="table-border-full"] table {
+		--inset-start: 1ch;
+		--inset-end: 1ch;
+		margin-block: 1lh;
+		border-collapse: collapse;
+	}
+	[data-remarkdown~="table-border"] tr > *,
+	[data-remarkdown~="table-border-full"] tr > * {
+		position: relative;
+		padding-block: 0;
+		padding-inline-start: var(--inset-start);
+		padding-inline-end: var(--inset-end);
+		border: none;
+		vertical-align: top;
+		font-weight: inherit;
+		text-align: match-parent;
+	}
+	[data-remarkdown~="table-border"] tr > :first-child {
+		--inset-start: 0ch;
+	}
+	[data-remarkdown~="table-border"] tr > :last-child {
+		--inset-end: 0ch;
+	}
+	[data-remarkdown~="table-border"] :is(thead th, thead td, th[scope="col"]),
+	[data-remarkdown~="table-border-full"] :is(thead th, thead td, th[scope="col"]) {
+		--inset-total: calc(var(--inset-start) + var(--inset-end));
 		padding-bottom: 1lh;
 	}
-	[data-remarkdown~="table-marker"] tr:first-child > th:not([scope="row"])::after {
-		content: "--------------------------------------------------------------------------------------------------------------"/"";
+	[data-remarkdown~="table-border"] :is(thead th, thead td, th[scope="col"])::after,
+	[data-remarkdown~="table-border-full"] :is(thead th, thead td, th[scope="col"])::after {
+		content: var(--rmd-table-hline) var(--rmd-table-hline)/"";
 		position: absolute;
 		bottom: 0;
-		inset-inline: 0;
+		inset-inline-start: var(--inset-start);
+		width: calc(100% - var(--inset-total));
+		max-width: 100%;
+		height: 1lh;
 		overflow: hidden;
 		word-break: break-all;
-		height: 1lh;
 	}
-	[data-remarkdown~="table-marker"] tr:first-child > * + th:not([scope="row"])::after {
-		inset-inline-start: 3ch;
+	@supports (width: round(down, 100%, 1ch)) {
+		[data-remarkdown~="table-border"] :is(thead th, thead td, th[scope="col"])::after,
+		[data-remarkdown~="table-border-full"] :is(thead th, thead td, th[scope="col"])::after {
+			width: round(down, 100% - var(--inset-total), 1ch);
+		}
 	}
-	[data-remarkdown~="table-marker"] tr > * + *::before {
-		content: "|\a|\a|\a|\a|\a|\a|\a|\a|\a|\a"/"";
+	[data-remarkdown~="table-border"] tr > *::before,
+	[data-remarkdown~="table-border-full"] tr > *::before {
+		content: none;
 		position: absolute;
 		inset-block: 0;
-		inset-inline-start: 1ch;
+		inset-inline-start: 0;
+		width: 1ch;
 		overflow: hidden;
 		white-space: pre;
+	}
+	[data-remarkdown~="table-border"] table {
+		--inset-start: 2ch;
+	}
+	[data-remarkdown~="table-border"] tr > :not(:first-child)::before {
+		content: var(--rmd-table-vline)/"";
+	}
+	[data-remarkdown~="table-border-full"] table {
+		--inset-start: 2ch;
+	}
+	[data-remarkdown~="table-border-full"] tr {
+		position: relative;
+	}
+	[data-remarkdown~="table-border-full"] tr::after {
+		content: var(--rmd-table-vline)/"";
+		position: absolute;
+		inset-block: 0;
+		inset-inline-end: 0;
+		width: 1ch;
+		overflow: hidden;
+		white-space: pre;
+	}
+	[data-remarkdown~="table-border-full"] tr > :last-child {
+		--inset-end: 2ch;
+	}
+	[data-remarkdown~="table-border-full"] tr > *::before {
+		content: var(--rmd-table-vline)/"";
 	}
 }
 /* Demo layout and page styles */
@@ -746,7 +899,7 @@
 	color: var(--text-color);
 	background-color: var(--bg-color);
 }
-@media (width >= 900px) {
+@media (width >= 56em) {
 	:root {
 		background-color: var(--bg-alt-color);
 	}
@@ -754,16 +907,16 @@
 
 body {
 	--body-padding-inline: 2rem;
-	margin: 0;
+	max-width: 66ch;
+	margin-block: 0;
+	margin-inline: auto;
 	padding-block: 2rem 3rem;
 	padding-inline: var(--body-padding-inline);
 }
-@media (width >= 900px) {
+@media (width >= 56em) {
 	body {
 		--body-padding-inline: 4.5rem;
-		max-width: 66ch;
 		margin-block: 2rem;
-		margin-inline: auto;
 		padding-block: 2.5rem 3.5rem;
 		border: 1px solid var(--bg-border-color);
 		background-color: var(--bg-color);
@@ -810,7 +963,7 @@ main > :last-child {
 		white-space: pre-wrap;
 		color: var(--code-color);
 	}
-	@media (width < 700px) {
+	@media (width < 40em) {
 		pre {
 			margin-inline-start: 0;
 		}
@@ -834,7 +987,7 @@ nav > :first-child {
 nav > br {
 	display: none;
 }
-@media (width >= 700px) {
+@media (width >= 40em) {
 	nav {
 		flex-direction: row;
 		gap: 2ch;
@@ -860,7 +1013,7 @@ nav > br {
 #styles-list tr > :first-child {
 	white-space: nowrap;
 }
-@media (width < 700px) {
+@media (width < 40em) {
 	#styles-list tr > :last-child {
 		display: none;
 	}

--- a/docs/docs.scss
+++ b/docs/docs.scss
@@ -1,7 +1,19 @@
 /**
- * Styles for ReMarkdown demo pages
+ * Styles for ReMarkdown documentation pages.
+ *
+ * Includes two builds of ReMarkdown:
+ *
+ * 1. `.remarkdown` class and `default` options preset;
+ * 2. `[data-remarkdown]` attribute and `zero` options preset.
+ *
+ * We're using CSS scoping with `@scope (.remarkdown) to ([data-remarkdown])`
+ * to ensure that we can switch from one build to the other in the same HTML page.
  */
+
 @use "../lib/rmd";
+
+$breakpoint-small: 40em;
+$breakpoint-medium: 56em;
 
 @layer remarkdown {
 	/// Class-based build of ReMarkdown using default styles
@@ -49,22 +61,22 @@
 	color: var(--text-color);
 	background-color: var(--bg-color);
 
-	@media (width >= 900px) {
+	@media (width >= $breakpoint-medium) {
 		background-color: var(--bg-alt-color);
 	}
 }
 
 body {
 	--body-padding-inline: 2rem;
-	margin: 0;
+	max-width: 66ch;
+	margin-block: 0;
+	margin-inline: auto;
 	padding-block: 2rem 3rem;
 	padding-inline: var(--body-padding-inline);
 
-	@media (width >= 900px) {
+	@media (width >= $breakpoint-medium) {
 		--body-padding-inline: 4.5rem;
-		max-width: 66ch;
 		margin-block: 2rem;
-		margin-inline: auto;
 		padding-block: 2.5rem 3.5rem;
 		border: 1px solid var(--bg-border-color);
 		background-color: var(--bg-color);
@@ -114,7 +126,7 @@ main {
 		tab-size: 2;
 		white-space: pre-wrap;
 		color: var(--code-color);
-		@media (width < 700px) {
+		@media (width < $breakpoint-small) {
 			margin-inline-start: 0;
 		}
 	}
@@ -141,7 +153,7 @@ nav {
 		display: none;
 	}
 
-	@media (width >= 700px) {
+	@media (width >= $breakpoint-small) {
 		flex-direction: row;
 		gap: 2ch;
 		text-align: right;
@@ -170,7 +182,7 @@ nav {
 	tr > :first-child {
 		white-space: nowrap;
 	}
-	@media (width < 700px) {
+	@media (width < $breakpoint-small) {
 		tr > :last-child {
 			display: none;
 		}

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<title>ReMarkdown — this CSS makes HTML look like plain text</title>
 	<meta name="viewport" content="width=device-width">
-	<link rel="stylesheet" href="./demo.css">
+	<link rel="stylesheet" href="./docs.css">
 </head>
 <body class="remarkdown h1-line h2-line em-underscore">
 

--- a/docs/styles.html
+++ b/docs/styles.html
@@ -4,9 +4,9 @@
 	<meta charset="utf-8">
 	<title>ReMarkdown — Available styles</title>
 	<meta name="viewport" content="width=device-width">
-	<link rel="stylesheet" href="./demo.css">
+	<link rel="stylesheet" href="./docs.css">
 </head>
-<body class="remarkdown h1-line h2-line em-underscore table-marker">
+<body class="remarkdown h1-line h2-line em-underscore table-border">
 
 <nav>
 	<span>ReMarkdown</span>
@@ -172,14 +172,24 @@
 		<td>Horizontally center HRs</td>
 	</tr>
 	<tr>
-		<td><a href="#del-gfm">del-gfm</a></td>
+		<td><a href="#del-tilde">del-tilde</a></td>
 		<td>—</td>
 		<td>Wrap DEL in “~~” (<a href="https://help.github.com/articles/github-flavored-markdown#strikethrough">GFM style</a>)</td>
 	</tr>
 	<tr>
-		<td><a href="#table-marker">table-marker</a></td>
+		<td><a href="#table-reset">table-reset</a></td>
 		<td>—</td>
-		<td>Add markers to TABLE (<a href="https://michelf.ca/projects/php-markdown/extra/#table">syntax</a>)</td>
+		<td>Plain text rendering for TABLE</td>
+	</tr>
+	<tr>
+		<td><a href="#table-border">table-border</a></td>
+		<td>—</td>
+		<td>Use “|” and “-” for TABLE borders</td>
+	</tr>
+	<tr>
+		<td><a href="#table-border-full">table-border-full</a></td>
+		<td>—</td>
+		<td>Add left and right borders</td>
 	</tr>
 </table>
 
@@ -482,31 +492,34 @@
 	Other
 </h2>
 
-<h3 id="del-gfm">
-	Option: <code>del-gfm</code>
+<h3 id="del-tilde">
+	Option: <code>del-tilde</code>
 </h3>
 
-<figure data-remarkdown="del-gfm">
-	<p>ReMarkdown is <del>ridiculous</del> <ins>excellent</ins>.</p>
+<figure data-remarkdown="del-tilde">
+	<p>ReMarkdown is <del>preposterous</del> <ins>peculiar</ins>.</p>
 </figure>
 
 <h2>
 	Tables
 </h2>
 
-<h3 id="table-marker">
-	Option: <code>table-marker</code>
+<h3 id="table-reset">
+	Option: <code>table-reset</code>
 </h3>
 
-<p>Print <code>|</code> separators between columns, and <code>--</code> underlines below column headers. This style draws inspiration from <a href="https://michelf.ca/projects/php-markdown/extra/#table">Markdown Extra</a>.</p>
+<p>Resets some table styles: no borders, no centered text, no bold table headers.</p>
 
-<figure data-remarkdown="table-marker">
+<figure data-remarkdown="table-reset">
 	<table>
+	<thead>
 		<tr>
 			<th scope="col">Col 1</th>
 			<th scope="col">Col 2</th>
 			<th scope="col">Col 3</th>
 		</tr>
+	</thead>
+	<tbody>
 		<tr>
 			<td>Lorem ipsum</td>
 			<td>Dolor sit amet</td>
@@ -517,25 +530,67 @@
 			<td>Excepturi laudantium molestiae nam</td>
 			<td>Repellat ab nostrum, est tempora minus dolores magni voluptatibus?</td>
 		</tr>
+	</tbody>
 	</table>
 </figure>
 
-<p>Row headers don’t have markers:</p>
+<h3 id="table-border">
+	Option: <code>table-border</code>
+</h3>
 
-<figure data-remarkdown="table-marker">
+<p>Print <code>|</code> separators between columns, and <code>--</code> underlines below column headers. This style draws inspiration from <a href="https://michelf.ca/projects/php-markdown/extra/#table">Markdown Extra</a>.</p>
+
+<figure data-remarkdown="table-border">
 	<table>
+	<thead>
 		<tr>
-			<th scope="row">Row 1</th>
+			<th scope="col">Col 1</th>
+			<th scope="col">Col 2</th>
+			<th scope="col">Col 3</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
 			<td>Lorem ipsum</td>
 			<td>Dolor sit amet</td>
 			<td>Consectetur adipisicing elit</td>
 		</tr>
 		<tr>
-			<th scope="row">Row 2</th>
 			<td>Quae enim corrupti</td>
 			<td>Excepturi laudantium molestiae nam</td>
 			<td>Repellat ab nostrum, est tempora minus dolores magni voluptatibus?</td>
 		</tr>
+	</tbody>
+	</table>
+</figure>
+
+<h3 id="table-border-full">
+	Option: <code>table-border-full</code>
+</h3>
+
+<p>Also print <code>|</code> borders at the left and right edges of the table. Works in Chrome and Firefox, but only partially in Safari (rightmost border will be missing; WebKit doesn’t support pseudo-elements for <code>&lt;tr&gt;</code>).</p>
+
+<figure data-remarkdown="table-border-full">
+	<table>
+	<thead>
+		<tr>
+			<th scope="col">Col 1</th>
+			<th scope="col">Col 2</th>
+			<th scope="col">Col 3</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Lorem ipsum</td>
+			<td>Dolor sit amet</td>
+			<td>Consectetur adipisicing elit</td>
+		</tr>
+		<tr>
+			<td>Quae enim corrupti</td>
+			<td>Excepturi laudantium molestiae nam</td>
+			<td>Repellat ab nostrum, est tempora minus dolores magni voluptatibus?</td>
+		</tr>
+	</tbody>
 	</table>
 </figure>
 

--- a/lib/config/_defaults.scss
+++ b/lib/config/_defaults.scss
@@ -70,8 +70,9 @@ $default-styles: (
 	hr-star,
 	// hr-dash,
 	// hr-center,
-	// del-gfm,
-	// table-marker,
+	// del-tilde,
+	// table-reset,
+	// table-border,
 );
 
 // Font stack to use.
@@ -86,18 +87,10 @@ $code-font: inherit;
 // Root line-height (as a unit-less ratio, e.g. `1.5`)
 $line-height: 1.5;
 
-// Size of one step of vertical margin.
-// Typically, the height of a single line of text.
-$margin-block-base: 1lh;
-
-// Size of one step of horizontal margin.
-// Typically, the width of one space character.
-$margin-inline-base: 1ch;
-
 // Vertical and horizontal margins for elements, as unitless numbers:
-// - vertical margins ("top" and "bottom") are multiples of the base line-height.
-// - horizontal margind ("inline-start" and "inline-end")
-// By default we use one line for everything, but you can specify more here:
+// - vertical margins ("top" and "bottom") are multiples of the base line-height;
+// - horizontal margins ("inline-start" and "inline-end") are multiples of the
+//   width of a single space (`1ch`).
 $margins: (
 	h1: (
 		top: 1.5,
@@ -167,3 +160,7 @@ $h2-line: "----------------------------------------";
 // Horizontal rules
 $hr-stars: "* * * *";
 $hr-dashes: "-------";
+
+// Table decorations
+$table-vline: "|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A|\A";
+$table-hline: "----------------------------------------";

--- a/lib/styles/_base.scss
+++ b/lib/styles/_base.scss
@@ -5,25 +5,32 @@
 @use "../toolkit" as *;
 
 @mixin base {
+	$vars: (
+		font,
+		code-font,
+		line-height,
+		hn-prefix,
+		h1-line,
+		h2-line,
+		hr-stars,
+		hr-dashes,
+		table-vline,
+		table-hline
+	);
+
 	@include root() {
-		@include define-var(font);
-		@include define-var(code-font);
-		@include define-var(line-height);
-		@include define-var(hn-prefix);
-		@include define-var(h1-line);
-		@include define-var(h2-line);
-		@include define-var(hr-stars);
-		@include define-var(hr-dashes);
-		@include define-var(margin-block-base);
+		@each $var in $vars {
+			@include define-var($var, config.get($var));
+		}
 	}
 
 	@include option(base-text) {
 		& {
-			font-family: var(var-name(font));
-			line-height: var(var-name(line-height));
+			font-family: rmd-var(font);
+			line-height: rmd-var(line-height);
 		}
 		:is(pre, code, kbd, samp) {
-			font-family: var(var-name(code-font));
+			font-family: rmd-var(code-font);
 		}
 	}
 }

--- a/lib/styles/_del.scss
+++ b/lib/styles/_del.scss
@@ -1,12 +1,13 @@
 // <del>
-// Options: del-gfm
+// Options: del-tilde
 
 @use "../toolkit" as *;
 
 @mixin del {
-	@include option(del-gfm) {
+	@include option(del-tilde) {
 		del {
-			text-decoration: none;
+			text-decoration-inset: 2.2ch;
+			text-decoration-thickness: round(up, 0.08em, 0.5px);
 		}
 		del::before,
 		del::after {

--- a/lib/styles/_hn.scss
+++ b/lib/styles/_hn.scss
@@ -26,7 +26,7 @@
 	}
 
 	@include option(hn-prefix) {
-		$prefix: var(var-name(hn-prefix));
+		$prefix: rmd-var(hn-prefix);
 		@for $i from 1 through 6 {
 			h#{$i}::before {
 				@include content($prefix, $repeat: $i, $suffix: " ");
@@ -35,14 +35,14 @@
 	}
 
 	@include option(h1-line) {
-		$line: var(var-name(h1-line));
+		$line: rmd-var(h1-line);
 		h1 {
 			@include -hn-line($line);
 		}
 	}
 
 	@include option(h2-line) {
-		$line: var(var-name(h2-line));
+		$line: rmd-var(h2-line);
 		h2 {
 			@include -hn-line($line);
 		}
@@ -53,7 +53,7 @@
 	& {
 		position: relative;
 		width: fit-content;
-		padding-bottom: line();
+		padding-bottom: row();
 	}
 	&::before {
 		content: none;
@@ -63,7 +63,7 @@
 		position: absolute;
 		bottom: 0;
 		inset-inline: 0;
-		height: line();
+		height: row();
 		width: 100%;
 		overflow: hidden;
 		word-break: break-all;

--- a/lib/styles/_hr.scss
+++ b/lib/styles/_hr.scss
@@ -1,19 +1,21 @@
 // <hr>
 // Options: hr-center, hr-star, hr-dash
 
-@use "../config";
 @use "../toolkit" as *;
 
 @mixin hr {
-	$stars: var(var-name(hr-stars));
-	$dashes: var(var-name(hr-dashes));
-
-	@include root {
+	@include root() {
 		hr {
-			height: line();
-			line-height: line();
+			height: auto;
 			margin-block: margins(hr);
 			margin-inline: 0;
+			line-height: inherit;
+			text-align: start;
+		}
+	}
+
+	@include option(hr-star hr-dash) {
+		hr {
 			border: none;
 			color: inherit;
 		}
@@ -25,15 +27,18 @@
 		}
 	}
 
+
 	@include option(hr-star) {
 		hr::before {
-			@include content($stars);
+			@include content(rmd-var(hr-stars));
+			display: block;
 		}
 	}
 
 	@include option(hr-dash) {
 		hr::before {
-			@include content($dashes);
+			@include content(rmd-var(hr-dashes));
+			display: block;
 		}
 	}
 }

--- a/lib/styles/_pre.scss
+++ b/lib/styles/_pre.scss
@@ -54,6 +54,6 @@
 @mixin -pre-fence-pseudo {
 	display: block;
 	width: 100%;
-	height: line();
+	height: row();
 	cursor: default;
 }

--- a/lib/styles/_quote.scss
+++ b/lib/styles/_quote.scss
@@ -4,6 +4,9 @@
 @use "../toolkit" as *;
 
 @mixin quote {
+	$quote-mark-ltr: str-repeat(">\A", 20);
+	$quote-mark-rtl: str-repeat("<\A", 20);
+
 	@include root() {
 		blockquote {
 			margin-block: margins(blockquote);
@@ -14,10 +17,14 @@
 
 	@include option(quote-gt) {
 		blockquote {
+			@include define-var(quote-mark, $quote-mark-ltr);
 			position: relative;
 		}
+		blockquote:dir(rtl) {
+			@include define-var(quote-mark, $quote-mark-rtl);
+		}
 		blockquote::before {
-			@include content(str-repeat(">\A>\A>\A>\A>\A>\A>\A>\A>\A>\A", 20));
+			@include content(rmd-var(quote-mark), $repeat: 4);
 			position: absolute;
 			inset-block: 0;
 			inset-inline-start: -2ch;
@@ -25,9 +32,6 @@
 			overflow: hidden;
 			white-space: pre;
 			cursor: default;
-		}
-		blockquote:dir(rtl)::before {
-			@include content(str-repeat("<\A<\A<\A<\A<\A<\A<\A<\A<\A<\A", 20));
 		}
 	}
 }

--- a/lib/styles/_table.scss
+++ b/lib/styles/_table.scss
@@ -1,48 +1,123 @@
 // <table>
-// Option: table-marker
+// Option: table-border
 
 @use "../toolkit" as *;
 
 @mixin table {
-	@include option(table-marker) {
+	@include option(table-reset) {
 		table {
 			margin-block: margins(table);
 			border-collapse: collapse;
 		}
 		tr > * {
-			min-width: 2ch;
-			position: relative;
-			padding: 0;
-			text-align: inherit;
-			vertical-align: top;
-			font-weight: normal;
+			padding-block: 0;
+			padding-inline: col(1);
 			border: none;
+			vertical-align: top;
+			font-weight: inherit;
+			text-align: match-parent;
 		}
-		tr > * + * {
-			padding-inline-start: 3ch;
+		tr > :first-child {
+			padding-inline-start: 0;
 		}
-		tr:first-child > th:not([scope="row"]) {
-			padding-bottom: line();
+		tr > :last-child {
+			padding-inline-end: 0;
 		}
-		tr:first-child > th:not([scope="row"])::after {
-			@include content(str-repeat("-----------", 10));
-			position: absolute;
-			bottom: 0;
-			inset-inline: 0;
-			overflow: hidden;
-			word-break: break-all;
-			height: line();
+	}
+
+	@include option(table-border table-border-full) {
+		table {
+			--inset-start: #{col()};
+			--inset-end: #{col()};
+			margin-block: margins(table);
+			border-collapse: collapse;
 		}
-		tr:first-child > * + th:not([scope="row"])::after {
-			inset-inline-start: 3ch;
+		tr > * {
+			position: relative;
+			padding-block: 0;
+			padding-inline-start: var(--inset-start);
+			padding-inline-end: var(--inset-end);
+			border: none;
+			vertical-align: top;
+			font-weight: inherit;
+			text-align: match-parent;
 		}
-		tr > * + *::before {
-			@include content(str-repeat("|\A", 10));
+	}
+
+	@include option(table-border) {
+		tr > :first-child {
+			--inset-start: 0ch;
+		}
+		tr > :last-child {
+			--inset-end: 0ch;
+		}
+	}
+
+	@include option(table-border table-border-full) {
+		// th markers
+		:is(thead th, thead td, th[scope="col"]) {
+			--inset-total: calc(var(--inset-start) + var(--inset-end));
+			padding-bottom: row();
+
+			&::after {
+				@include content(rmd-var(table-hline), $repeat: 2);
+				position: absolute;
+				bottom: 0;
+				inset-inline-start: var(--inset-start);
+				width: calc(100% - var(--inset-total));
+				max-width: 100%;
+				height: row();
+				overflow: hidden;
+				word-break: break-all;
+
+				@supports (width: round(down, 100%, 1ch)) {
+					width: round(down, 100% - var(--inset-total), 1ch);
+				}
+			}
+		}
+
+		// column markers (shared style)
+		tr > *::before {
+			content: none;
 			position: absolute;
 			inset-block: 0;
-			inset-inline-start: 1ch;
+			inset-inline-start: 0;
+			width: col();
 			overflow: hidden;
 			white-space: pre;
+		}
+	}
+
+	@include option(table-border) {
+		table {
+			--inset-start: #{col(2)};
+		}
+		tr > :not(:first-child)::before {
+			@include content(rmd-var(table-vline));
+		}
+	}
+
+	@include option(table-border-full) {
+		table {
+			--inset-start: #{col(2)};
+		}
+		tr {
+			position: relative;
+		}
+		tr::after {
+			@include content(rmd-var(table-vline));
+			position: absolute;
+			inset-block: 0;
+			inset-inline-end: 0;
+			width: col();
+			overflow: hidden;
+			white-space: pre;
+		}
+		tr > :last-child {
+			--inset-end: #{col(2)};
+		}
+		tr > *::before {
+			@include content(rmd-var(table-vline));
 		}
 	}
 }

--- a/lib/styles/_ul.scss
+++ b/lib/styles/_ul.scss
@@ -37,9 +37,9 @@
 		ul > li::before {
 			@include content($bullet);
 			float: inline-start;
-			width: col(1);
+			width: col();
 			margin-inline-start: indent(ul, start) * -1;
-			margin-inline-end: col(1);
+			margin-inline-end: col();
 		}
 	}
 }

--- a/lib/toolkit/_output.scss
+++ b/lib/toolkit/_output.scss
@@ -5,11 +5,19 @@
 @use "../config";
 @use "./utils" as *;
 
-/// Define a CSS custom property for a config value
-@mixin define-var($name) {
-	$value: config.get($name);
+/// Define a CSS custom property
+@mixin define-var($name, $value) {
 	@if $value != null {
 		#{var-name($name)}: $value;
+	}
+}
+
+@function rmd-var($name, $default: null) {
+	$prop: var-name($name);
+	@if $default != null {
+		@return var($prop, $default);
+	} @else {
+		@return var($prop);
 	}
 }
 
@@ -48,7 +56,7 @@
 		@error "Unknown direction #{$direction}";
 	}
 	$num: config.get(margins $element $direction) or 1;
-	@return line($num);
+	@return row($num);
 }
 
 /// Get both vertical margin values for an element.
@@ -80,15 +88,13 @@
 }
 
 /// Compute the size of a text line
-@function line($count: 1) {
-	$base: config.get(margin-block-base);
-	@return $base * $count;
+@function row($count: 1) {
+	@return $count * 1lh;
 }
 
-/// Compute the size of a text column (typically, one fixed-width character)
+/// Compute the size of a text column
 @function col($count: 1) {
-	$base: config.get(margin-inline-base);
-	@return $base * $count;
+	@return $count * 1ch;
 }
 
 @function -short-pair($a, $b) {

--- a/lib/toolkit/_selector.scss
+++ b/lib/toolkit/_selector.scss
@@ -1,3 +1,4 @@
+@use "sass:list";
 @use "sass:meta" as *;
 
 @use "../config";
@@ -5,7 +6,7 @@
 
 /// Wrap content in the base selector
 @mixin root() {
-	$selector: -root-selector();
+	$selector: root-selector();
 	@if $selector {
 		#{$selector} {
 			@content;
@@ -15,23 +16,23 @@
 	}
 }
 
-/// Wrap content in a selector including the option name, depending on
+/// Wrap content in a selector including the option name(s), depending on
 /// the content of $defaults and the value of $output-all-styles.
 /// Outputs nothing if $output-all-styles is false and the option is not
-/// in $defaults.
-@mixin option($name) {
-	@if config.default-option($name) {
+/// in $default-styles.
+@mixin option($names) {
+	@if config.default-option($names) {
 		@include root() {
 			@content;
 		}
 	} @else if config.get(output-all-styles) == true {
-		#{-option-selector($name)} {
+		#{option-selector($names)} {
 			@content;
 		}
 	}
 }
 
-@function -root-selector() {
+@function root-selector() {
 	$value: config.get(root-selector);
 	@if $value == null or $value == "" {
 		@return null;
@@ -39,7 +40,12 @@
 	@return $value;
 }
 
-@function -option-selector($name) {
+@function option-selector($names) {
 	$pattern: config.get(option-selector);
-	@return utils.str-replace($pattern, "%s", $name);
+	$selectors: ();
+	@each $name in $names {
+		$selector: utils.str-replace($pattern, "%s", $name);
+		$selectors: list.append($selectors, $selector, $separator: comma);
+	}
+	@return $selectors;
 }


### PR DESCRIPTION
BREAKING: renamed `table-marker` to `table-border`.

New: add `table-reset` and `table-border-full`.

Also refactors the `option()` mixin so that it supports multiple options, which lets us avoid some duplicated styles (at the cost of duplicated selectors sometimes).